### PR TITLE
Removing 405b for now due to download limitations

### DIFF
--- a/models/llama3_1/download.sh
+++ b/models/llama3_1/download.sh
@@ -13,7 +13,7 @@
 set -e
 
 read -p "Enter the URL from email: " PRESIGNED_URL
-ALL_MODELS_LIST="meta-llama-3.1-405b,meta-llama-3.1-70b,meta-llama-3.1-8b,meta-llama-guard-3-8b,prompt-guard"
+ALL_MODELS_LIST="meta-llama-3.1-70b,meta-llama-3.1-8b,meta-llama-guard-3-8b,prompt-guard"
 printf "\n **** Model list ***\n"
 for MODEL in ${ALL_MODELS_LIST//,/ }
 do


### PR DESCRIPTION
Unfortunately the file size is too big for curl and wget to support with AWS cloudfront, so disabling this until we find a solution.