### PR TITLE
Add missing fp8_scales files to `meta-llama-3.1-405b-fp8`

### DIFF
--- a/models/llama3_1/download.sh
+++ b/models/llama3_1/download.sh
@@ -87,6 +87,7 @@ do
         PTH_FILE_COUNT=7
         PTH_FILE_CHUNK_COUNT=3
         MODEL_PATH="Meta-Llama-3.1-405B"
+        ADDITIONAL_FILES="fp8_scales_0.pt,fp8_scales_1.pt,fp8_scales_2.pt,fp8_scales_3.pt,fp8_scales_4.pt,fp8_scales_5.pt,fp8_scales_6.pt,fp8_scales_7.pt"
     elif [[ $m == "meta-llama-3.1-70b-instruct" ]]; then
         PTH_FILE_COUNT=7
         MODEL_PATH="Meta-Llama-3.1-70B-Instruct"


### PR DESCRIPTION
I noticed that the `meta-llama-3.1-405b-fp8` model is missing the `fp8_scales` files. This PR adds the missing `ADDITIONAL_FILES`