### PR TITLE
Remove md5sum requirement

### DIFF
--- a/models/llama3_1/README.md
+++ b/models/llama3_1/README.md
@@ -30,7 +30,7 @@ To download the model weights and tokenizer, please visit the [Meta Llama websit
 
 Once your request is approved, you will receive a signed URL over email. Then, run the download.sh script, passing the URL provided when prompted to start the download.
 
-Pre-requisites: Ensure you have `wget` and `md5sum` installed. Then run the script: `./download.sh`.
+Pre-requisites: Ensure you have `wget` installed. Then run the script: `./download.sh`.
 
 Remember that the links expire after 24 hours and a certain amount of downloads. You can always re-request a link if you start seeing errors such as `403: Forbidden`.
 


### PR DESCRIPTION
There is no need for `md5sum` as long as we do not use checksums in the download script.