### PR TITLE
note inclusion of prev Q&A pairs in prompt for SQuAD eval in eval_det…

### DIFF
--- a/models/llama3_1/eval_details.md
+++ b/models/llama3_1/eval_details.md
@@ -65,8 +65,7 @@ For pre-trained models, we use a 3-shot config with CoT prompt and compute the a
 
 ### SQuAD
 
-For pre-trained models, we use SQuAD v2 with a 1-shot config and report exact match scores. We run this as a generative task. Maximum generation length is 32 tokens.
-
+For pre-trained models, we use SQuAD v2 with a 1-shot config and report exact match scores. We run this as a generative task. Maximum generation length is 32 tokens. In the prompt, we include the ground truth Q & A pairs for all previous questions pertaining to the same passage. In short, the prompt template takes the form "{few-shot example} {passage} {all previous Q & A pairs for passage} {input question}". For specifics, see the released [evaluation details dataset](https://huggingface.co/datasets/meta-llama/Meta-Llama-3.1-8B-evals/viewer/Meta-Llama-3.1-8B-evals__squad__details).
 
 ### QuAC
 


### PR DESCRIPTION
Change: 
* add a note in the llama3_1 eval_details.md file mentioning that for SQuAD prev Q & A pairs pertaining to a given passage are included in the prompt. 

Motivation: 
* To the best of my knowledge this evaluation detail isn't mentioned publicly except for in the eval details dataset. My hope is that also including it in the eval_details.md will help other researchers catch this important detail without having to dive deep into the eval details dataset.  