### PR TITLE
mmlu_pro metric should be macro_avg/acc instead of micro_avg/acc_char

### DIFF
--- a/models/llama3_1/MODEL_CARD.md
+++ b/models/llama3_1/MODEL_CARD.md
@@ -509,7 +509,7 @@ In this section, we report the results for Llama 3.1 models on standard automati
    </td>
    <td>5
    </td>
-   <td>micro_avg/acc_char
+   <td>macro_avg/acc
    </td>
    <td>45.5
    </td>


### PR DESCRIPTION
This is a typo in our model_card, mmlu_pro metric for instruct models should be macro_avg/acc instead of micro_avg/acc_char.