### PR TITLE
added micro-avg metrics for MMLU-Pro to eval_details.md

### DIFF
--- a/models/llama3_1/eval_details.md
+++ b/models/llama3_1/eval_details.md
@@ -22,6 +22,7 @@ Macro averages are reported unless otherwise stated. The micro average scores fo
 
 For the pre-trained and post-trained models we use a 5-shot config with CoT prompt. We ask the model to generate the reasoning and the corresponding best choice character. The maximum generation length is 512 tokens for pre-trained setup and 1024 for post-trained setup.
 
+Macro averages are reported unless otherwise stated. The micro average scores for the various models are: 35.6, 52.0, and 59.6 for the pre-trained 8B, 70B and 405B models; 47.0, 65.1, 72.2 for the post-trained 8B, 70B and 405B models.
 
 ### ARC-Challenge
 


### PR DESCRIPTION
Following the example in the MMLU eval details, this PR added micro-avg metrics for MMLU-Pro to eval_details.md, as many people are confused when reproducing our eval results, as they can only reproduce the micro-avg, and  have asked for this. The micro-avg can be found in the metric subset for each evals dataset but it will be easier to add it here for people to review.