### PR TITLE
Updating tool call formats in llama cli

### DIFF
--- a/models/llama3_1/api/templates/system_message.builtin_and_custom_tools.yaml
+++ b/models/llama3_1/api/templates/system_message.builtin_and_custom_tools.yaml
@@ -3,22 +3,22 @@ custom_tools:
   - tool_name: get_boiling_point
     description: Get the boiling point of a liquid
     parameters:
-      - liquid_name:
-        - type: string
-        - description: name of the liquid
-        - required: True
-      - celsius:
-        - type: boolean
-        - description: whether to return the boiling point in celsius
-        - required: False
+      - name: liquid_name
+        type: string
+        description: name of the liquid
+        required: True
+      - name: celsius
+        type: boolean
+        description: whether to use celsius
+        required: False
   - tool_name: trending_songs
     description: Returns the trending songs on a Music site
     parameters:
-      - country:
-          type: string
-          description: The country to return trending songs for
-          required: True
-      - n:
-          type: int
-          description: The number of songs to return
-          required: False
+      - name: country
+        type: string
+        description: country to return trending songs for
+        required: True
+      - name: n
+        type: int
+        description: The number of songs to return
+        required: False

--- a/models/llama3_1/api/templates/system_message.custom_tools_only.yaml
+++ b/models/llama3_1/api/templates/system_message.custom_tools_only.yaml
@@ -3,22 +3,22 @@ custom_tools:
   - tool_name: get_boiling_point
     description: Get the boiling point of a liquid
     parameters:
-      - liquid_name:
-        - type: string
-        - description: name of the liquid
-        - required: True
-      - celsius:
-        - type: boolean
-        - description: whether to return the boiling point in celsius
-        - required: False
+      - name: liquid_name
+        type: string
+        description: name of the liquid
+        required: True
+      - name: celsius
+        type: boolean
+        description: whether to use celsius
+        required: False
   - tool_name: trending_songs
     description: Returns the trending songs on a Music site
     parameters:
-      - country:
-          type: string
-          description: The country to return trending songs for
-          required: True
-      - n:
-          type: int
-          description: The number of songs to return
-          required: False
+      - name: country
+        type: string
+        description: country to return trending songs for
+        required: True
+      - name: n
+        type: int
+        description: The number of songs to return
+        required: False

--- a/models/llama3_1/api/templates/system_message.jinja
+++ b/models/llama3_1/api/templates/system_message.jinja
@@ -12,28 +12,41 @@ Today Date: {{ today }}
 {%- if custom_tools %}
 {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
 
-You have access to the following functions:
-
+Answer the user's question by making use of the following functions if needed.
+If none of the function can be used, please say so.
+Here is a list of functions in JSON format:
 {% for t in custom_tools %}
 {#- manually setting up JSON because jinja sorts keys in unexpected ways -#}
 {%- set tname = t.tool_name -%}
 {%- set tdesc = t.description -%}
-{%- set tparams = t.parameters | tojson -%}
-Use the function '{{ tname }}' to '{{ tdesc }}':
-{"name": "{{tname}}", "description": "{{tdesc}}", "parameters": {{tparams}}}
-
-{% endfor -%}
-Think very carefully before calling functions.
-If a you choose to call a function ONLY reply in the following format with no prefix or suffix:
-
-<function=example_function_name>{"example_name": "example_value"}</function>
-
-Reminder:
-- If looking for real time information use relevant functions before falling back to brave_search
-- Function calls MUST follow the specified format, start with <function= and end with </function>
-- Required parameters MUST be specified
-- Only call one function at a time
-- Put the entire function call reply on one line
+{%- set tparams = t.parameters -%}
+{%- set required_params = [] -%}
+{%- for param in tparams if param.required == true -%}
+    {%- set _ = required_params.append(param.name) -%}
+{%- endfor -%}
+{
+    "type": "function",
+    "function": {
+        "name": "{{tname}}",
+        "description": "{{tdesc}}",
+        "parameters": {
+            "type": "object",
+            "properties": [
+                {%- for param in tparams %}
+                {
+                    "{{param.name}}": {
+                        "type": "object",
+                        "description": "{{param.description}}"
+                    }
+                }{% if not loop.last %},{% endif %}
+                {%- endfor %}
+            ],
+            "required": {{ required_params | tojson }}
+        }
+    }
+}
+{% endfor %}
+Return function calls in JSON format.
 <|eot_id|>
 {%- endif -%}
 {{ additional_instructions -}}


### PR DESCRIPTION
Updated default tool call format to reflect json format message provided as a user message. 
```
llama model template --name system-builtin-and-custom-tools
```
yields the following output
<img width="813" alt="image" src="https://github.com/user-attachments/assets/591ceb11-b0cf-4ee1-bb83-b5f2db32bc01">
