### PR TITLE
Remove duplicated target computation in generation.py

### DIFF
--- a/models/llama3/reference_impl/generation.py
+++ b/models/llama3/reference_impl/generation.py
@@ -209,10 +209,11 @@ class Llama:
             tokens[:, cur_pos] = next_token
 
             target = tokens[:, prev_pos + 1 : cur_pos + 1]
+            
             if logprobs:
                 token_logprobs[:, prev_pos + 1 : cur_pos + 1] = -F.cross_entropy(
                     input=logits.transpose(1, 2),
-                    target=tokens[:, prev_pos + 1 : cur_pos + 1],
+                    target=target,
                     reduction="none",
                     ignore_index=pad_id,
                 )


### PR DESCRIPTION
This CR deduplicates the `target` computation in `generation.py` for computing the token log probability with `cross_entropy`.