### PR TITLE
Minor typos

### DIFF
--- a/models/llama3_2/prompts_text.py
+++ b/models/llama3_2/prompts_text.py
@@ -145,7 +145,7 @@ def usecases():
             ],
             notes=textwrap.dedent(
                 """
-                - The tool call format for the mdoel is the same whether your function calls are provided in the system or user message.
+                - The tool call format for the model is the same whether your function calls are provided in the system or user message.
                 - While builtin tool calls end with a <|eom_id|>, notice the <|eot_id|> for zero shot tool calls.
                 """
             ),

--- a/models/llama3_2/text_prompt_format.md
+++ b/models/llama3_2/text_prompt_format.md
@@ -144,7 +144,7 @@ NO other text MUST be included.<|eot_id|><|start_header_id|>assistant<|end_heade
 
 ##### Notes
 
-- The tool call format for the mdoel is the same whether your function calls are provided in the system or user message.
+- The tool call format for the model is the same whether your function calls are provided in the system or user message.
 - While builtin tool calls end with a <|eom_id|>, notice the <|eot_id|> for zero shot tool calls.
 
 


### PR DESCRIPTION
Correction of a couple of minor typos of `mdoel` instead of `model`.

Example:
![image](https://github.com/user-attachments/assets/943bfa2a-4c10-4799-a571-a97bc71aabda)

