### PR TITLE
torch.triu is buggy on device='mps'. Add a workaround.

### DIFF
--- a/models/llama3/reference_impl/model.py
+++ b/models/llama3/reference_impl/model.py
@@ -313,6 +313,12 @@ class Transformer(nn.Module):
 
             mask = torch.triu(mask, diagonal=1)
 
+            # https://github.com/pytorch/pytorch/issues/100005
+            # torch.triu is buggy when the device is mps: filled values are 
+            # nan instead of 0. 
+            if mask.device.type == torch.device('mps').type:
+                mask = torch.nan_to_num(mask, nan=0.0)
+
             # When performing key-value caching, we compute the attention scores
             # only for the new sequence. Thus, the matrix of scores is of size
             # (seqlen, cache_len + seqlen), and the only masked entries are (i, j) for


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/100005

With this fix, I was able to run the model on my M1 air w/ device = 'mps'. 