### PR TITLE
Make `tokenizer_path` optional

### DIFF
--- a/models/llama3/reference_impl/generation.py
+++ b/models/llama3/reference_impl/generation.py
@@ -69,10 +69,10 @@ class Llama:
     @staticmethod
     def build(
         ckpt_dir: str,
-        tokenizer_path: str,
         max_seq_len: int,
         max_batch_size: int,
         model_parallel_size: Optional[int] = None,
+        tokenizer_path: Optional[str] = None,
         seed: int = 1,
     ):
         """
@@ -132,7 +132,11 @@ class Llama:
             max_batch_size=max_batch_size,
             **params,
         )
-        tokenizer = Tokenizer(model_path=tokenizer_path)
+        if tokenizer_path:
+            tokenizer = Tokenizer(model_path=tokenizer_path)
+        else:
+            tokenizer = Tokenizer.get_instance()
+
         assert model_args.vocab_size == tokenizer.n_words
         if torch.cuda.is_bf16_supported():
             torch.set_default_tensor_type(torch.cuda.BFloat16Tensor)

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -7,11 +7,11 @@
 
 import os
 import unittest
-import pytest
 
 from pathlib import Path
 
 import numpy as np
+import pytest
 from llama_models.llama3.api.datatypes import ImageMedia, SystemMessage, UserMessage
 
 from llama_models.llama3.reference_impl.generation import Llama
@@ -21,7 +21,6 @@ THIS_DIR = Path(__file__).parent
 
 
 def build_generator(env_var: str):
-    tokenizer_path = str(THIS_DIR.parent.parent / "api/tokenizer.model")
     if env_var not in os.environ:
         raise ValueError(f"{env_var} must be specified for this test")
 
@@ -31,7 +30,6 @@ def build_generator(env_var: str):
     os.environ["MASTER_PORT"] = "29501"
     return Llama.build(
         ckpt_dir=os.environ[env_var],
-        tokenizer_path=tokenizer_path,
         max_seq_len=128,
         max_batch_size=1,
         model_parallel_size=1,

--- a/models/scripts/example_chat_completion.py
+++ b/models/scripts/example_chat_completion.py
@@ -8,7 +8,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
-from pathlib import Path
 from typing import Optional
 
 import fire
@@ -21,9 +20,6 @@ from models.llama3.api.datatypes import (
 )
 
 from models.llama3.reference_impl.generation import Llama
-
-
-THIS_DIR = Path(__file__).parent.resolve()
 
 
 def run_main(
@@ -44,9 +40,7 @@ def run_main(
 
     `max_gen_len` is optional because finetuned models are able to stop generations naturally.
     """
-    tokenizer_path = str(THIS_DIR.parent / "llama3/api/tokenizer.model")
     generator = Llama.build(
-        ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,

--- a/models/scripts/example_chat_completion.py
+++ b/models/scripts/example_chat_completion.py
@@ -41,7 +41,7 @@ def run_main(
     `max_gen_len` is optional because finetuned models are able to stop generations naturally.
     """
     generator = Llama.build(
-        tokenizer_path=tokenizer_path,
+        ckpt_dir=ckpt_dir,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
         model_parallel_size=model_parallel_size,

--- a/models/scripts/example_text_completion.py
+++ b/models/scripts/example_text_completion.py
@@ -8,16 +8,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
-from pathlib import Path
 from typing import Optional
 
 import fire
 from termcolor import cprint
 
 from models.llama3.reference_impl.generation import Llama
-
-
-THIS_DIR = Path(__file__).parent.resolve()
 
 
 def run_main(
@@ -29,10 +25,8 @@ def run_main(
     max_gen_len: int = 64,
     model_parallel_size: Optional[int] = None,
 ):
-    tokenizer_path = str(THIS_DIR.parent / "llama3/api/tokenizer.model")
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
-        tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
         model_parallel_size=model_parallel_size,

--- a/models/scripts/multimodal_example_chat_completion.py
+++ b/models/scripts/multimodal_example_chat_completion.py
@@ -8,7 +8,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
-from pathlib import Path
 from typing import Optional
 
 import fire
@@ -20,9 +19,6 @@ from models.llama3.api.datatypes import ImageMedia, UserMessage
 from models.llama3.reference_impl.generation import Llama
 
 
-THIS_DIR = Path(__file__).parent.resolve()
-
-
 def run_main(
     ckpt_dir: str,
     temperature: float = 0.6,
@@ -32,10 +28,8 @@ def run_main(
     max_gen_len: Optional[int] = None,
     model_parallel_size: Optional[int] = None,
 ):
-    tokenizer_path = str(THIS_DIR.parent / "llama3/api/tokenizer.model")
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
-        tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
         model_parallel_size=model_parallel_size,

--- a/models/scripts/multimodal_example_text_completion.py
+++ b/models/scripts/multimodal_example_text_completion.py
@@ -8,7 +8,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
-from pathlib import Path
 from typing import Optional
 
 import fire
@@ -21,9 +20,6 @@ from models.llama3.api.datatypes import ImageMedia
 from models.llama3.reference_impl.generation import Llama
 
 
-THIS_DIR = Path(__file__).parent.resolve()
-
-
 def run_main(
     ckpt_dir: str,
     temperature: float = 0.6,
@@ -33,10 +29,8 @@ def run_main(
     max_gen_len: Optional[int] = None,
     model_parallel_size: Optional[int] = None,
 ):
-    tokenizer_path = str(THIS_DIR.parent / "llama3/api/tokenizer.model")
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
-        tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
         model_parallel_size=model_parallel_size,


### PR DESCRIPTION
We have `Tokenizer.get_instance()` which looks up the default path using the baked in tokenizer.model in the repository anyway. 