### PR TITLE
Explicitly define write permission for PRs within GitHub Actions workflow

### DIFF
--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -47,7 +47,7 @@ on:
 
       api_key:
         description: 'Provider API key'
-        required: true
+        required: false
         default: "---"
 
 env: 
@@ -55,11 +55,13 @@ env:
   MODELS_PATH: "/data/llama3.2"
   VISION_MODEL_CHECKPOINT_DIR: "/data/llama3.2/${{ inputs.model_vision }}"
   TEXT_MODEL_CHECKPOINT_DIR: "/data/llama3.2/${{ inputs.model_text }}"
-  API_KEY: "${{ inputs.api_key }}"
+  API_KEY: "${{ inputs.api_key || '' }}"
 
 jobs:
   execute_workflow:
     name: Execute workload on Self-Hosted CPU k8s runner
+    permissions:
+      pull-requests: write
     defaults:
       run:
         shell: bash # default shell to run all steps for a given job.


### PR DESCRIPTION
Explicitly define write permission for PR jobs so GitHub Action integrations requiring it have full access to the workflow resources.  See [this GitHub Actions repository explanation](https://github.com/thollander/actions-comment-pull-request?tab=readme-ov-file#permissions) for details.

Also set a default value for the environment variable `api_key`.