### PR TITLE
Update QuantizationArgs schema to incorporate spinquant, etc.

### DIFF
--- a/models/llama3/api/args.py
+++ b/models/llama3/api/args.py
@@ -6,12 +6,27 @@
 # the top-level of this source tree.
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
+
+
+class QuantizationScheme(Enum):
+    int4_weight_int8_dynamic_activation = "int4_weight_int8_dynamic_activation"
 
 
 @dataclass
 class QuantizationArgs:
+    scheme: Optional[QuantizationScheme] = None
     group_size: Optional[int] = None
+    spinquant: bool = False
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            if k == "scheme":
+                setattr(self, k, QuantizationScheme(v))
+            else:
+                if hasattr(self, k):
+                    setattr(self, k, v)
 
 
 @dataclass


### PR DESCRIPTION
As we produce more "official" quantized models, we need a proper representation in `ModelArgs` to be able to represent the weights precisely. 