### PR TITLE
feat: support non-cuda devices for text and vision models

### DIFF
--- a/models/llama3/reference_impl/generation.py
+++ b/models/llama3/reference_impl/generation.py
@@ -164,7 +164,7 @@ class Llama:
             from .multimodal.model import CrossAttentionTransformer
 
             model = CrossAttentionTransformer(model_args)
-            model.setup_cache(model_args.max_batch_size, torch.bfloat16)
+            model.setup_cache(model_args.max_batch_size, torch.get_default_dtype())
         else:
             model = Transformer(model_args)
         model.load_state_dict(checkpoint, strict=True)

--- a/models/llama3/reference_impl/model.py
+++ b/models/llama3/reference_impl/model.py
@@ -158,7 +158,7 @@ class Attention(nn.Module):
                 self.n_local_kv_heads,
                 self.head_dim,
             )
-        ).cuda()
+        )
         self.cache_v = torch.zeros(
             (
                 args.max_batch_size,
@@ -166,7 +166,7 @@ class Attention(nn.Module):
                 self.n_local_kv_heads,
                 self.head_dim,
             )
-        ).cuda()
+        )
 
     def forward(
         self,

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -32,6 +32,7 @@ def build_generator(env_var: str):
         max_seq_len=128,
         max_batch_size=1,
         model_parallel_size=1,
+        device=os.getenv("DEVICE", "cuda")
     )
 
 

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 from llama_models.llama3.api.datatypes import RawMediaItem, RawMessage, RawTextItem
 
 from llama_models.llama3.reference_impl.generation import Llama
@@ -19,7 +20,18 @@ from llama_models.llama3.reference_impl.generation import Llama
 THIS_DIR = Path(__file__).parent
 
 
-def build_generator(env_var: str):
+def get_device():
+    if 'DEVICE' in os.environ:
+        return os.environ['DEVICE']
+
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    return ""
+
+
+def build_generator(env_var: str, device: str):
     if env_var not in os.environ:
         raise ValueError(f"{env_var} must be specified for this test")
 
@@ -32,14 +44,16 @@ def build_generator(env_var: str):
         max_seq_len=128,
         max_batch_size=1,
         model_parallel_size=1,
-        device=os.getenv("DEVICE", "cuda")
+        device=device
     )
 
 
 class TestTextModelInference(unittest.TestCase):
+    device = "cpu"
+
     @classmethod
     def setUpClass(cls):
-        cls.generator = build_generator("TEXT_MODEL_CHECKPOINT_DIR")
+        cls.generator = build_generator("TEXT_MODEL_CHECKPOINT_DIR", cls.device)
 
     def test_run_generation(self):
         dialogs = [
@@ -69,10 +83,17 @@ class TestTextModelInference(unittest.TestCase):
             self.assertEqual(shape[1], 1)
 
 
+@pytest.mark.skipif(get_device() == "", reason="No device available and none specified")
+class TestTextModelInferenceOnDevice(TestTextModelInference):
+    device = get_device()
+
+
 class TestVisionModelInference(unittest.TestCase):
+    device = "cpu"
+
     @classmethod
     def setUpClass(cls):
-        cls.generator = build_generator("VISION_MODEL_CHECKPOINT_DIR")
+        cls.generator = build_generator("VISION_MODEL_CHECKPOINT_DIR", cls.device)
 
     @unittest.skip("Disabling vision model test")
     @pytest.mark.skip(reason="Disabling vision model test")
@@ -113,3 +134,8 @@ class TestVisionModelInference(unittest.TestCase):
             # assert at least 10 tokens
             self.assertTrue(shape[0] > 10)
             self.assertEqual(shape[1], 1)
+
+
+@pytest.mark.skipif(get_device() == "", reason="No device available and none specified")
+class TestVisionModelInferenceOnDevice(TestVisionModelInference):
+    device = get_device()


### PR DESCRIPTION
This commit adds support of non-cuda pytorch backend devices to text and vision models. Commit extends existing tests to run for the externally specified device (`cuda` is a default). Commit verified on Llama3.2-3B-Instruct and Llama3.2-11B-Vision-Instruct models for:
* `cuda` device type on NVidia A10 GPU (for no regressions)
* `cpu` device type
* `xpu` device type on Intel Data Center Max Series GPU (PVC)

Note that this commit requires a fix on pytorch side for gloo torch distributed backend to restore TLS on gloo working threads. This change was merged on pytorch side and should make it to pytorch 2.6.

This PR supersedes #165 from @anordin95.

Requires: https://github.com/pytorch/pytorch/pull/142184