### PR TITLE
ci: fix missing pypi packages for PR ci

### DIFF
--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -161,6 +161,7 @@ jobs:
           pip install llama-models
           pip install xmlrunner
           pip install pytest
+          pip install numpy
 
       - name: "Installing specific manual_dispatch dependencies"
         id: manual_install_pip


### PR DESCRIPTION
`numpy` is missing for PR ci. Example from #227:
* https://github.com/meta-llama/llama-models/actions/runs/11997550824/job/33443281106#step:11:28