### PR TITLE
Modeling code and nearby utilities should work with "raw" bytes not URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 dist
 *.egg-info
 build
+.DS_Store

--- a/models/llama3/api/chat_format.py
+++ b/models/llama3/api/chat_format.py
@@ -225,7 +225,6 @@ class ChatFormat:
             content = ""
 
         return ModelOutputMessage(
-            role="assistant",
             content=content,
             stop_reason=stop_reason,
             tool_calls=tool_calls,

--- a/models/llama3/api/datatypes.py
+++ b/models/llama3/api/datatypes.py
@@ -119,7 +119,6 @@ class StopReason(Enum):
 
 class RawMediaItem(BaseModel):
     type: Literal["image"]
-    format: Literal["png", "jpeg", "webp"]
     data: bytes | BytesIO
 
 
@@ -132,7 +131,7 @@ RawContentItem = Annotated[
     Union[RawTextItem, RawMediaItem], Field(discriminator="type")
 ]
 
-RawContent = List[RawContentItem]
+RawContent = str | RawContentItem | List[RawContentItem]
 
 
 class ModelInputMessage(BaseModel):

--- a/models/llama3/api/datatypes.py
+++ b/models/llama3/api/datatypes.py
@@ -136,21 +136,13 @@ RawContentItem = Annotated[
 RawContent = str | RawContentItem | List[RawContentItem]
 
 
-class ModelInputMessage(BaseModel):
-    role: Literal["user", "system", "ipython"]
+class RawMessage(BaseModel):
+    role: Literal["user", "system", "ipython", "assistant"]
     content: RawContent
 
     # This is for RAG but likely should be absorbed into content
     context: Optional[RawContent] = None
 
-
-class ModelOutputMessage(BaseModel):
-    role: Literal["assistant"] = "assistant"
-    content: RawContent
-    stop_reason: StopReason
+    # These are for the output message coming from the assistant
+    stop_reason: Optional[StopReason] = None
     tool_calls: List[ToolCall] = Field(default_factory=list)
-
-
-ModelMessage = Annotated[
-    Union[ModelInputMessage, ModelOutputMessage], Field(discriminator="role")
-]

--- a/models/llama3/api/datatypes.py
+++ b/models/llama3/api/datatypes.py
@@ -8,7 +8,7 @@
 from enum import Enum
 from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from typing_extensions import Annotated
 from ...datatypes import *  # noqa
@@ -118,12 +118,14 @@ class StopReason(Enum):
 
 
 class RawMediaItem(BaseModel):
-    type: Literal["image"]
+    type: Literal["image"] = "image"
     data: bytes | BytesIO
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class RawTextItem(BaseModel):
-    type: Literal["text"]
+    type: Literal["text"] = "text"
     text: str
 
 
@@ -138,9 +140,12 @@ class ModelInputMessage(BaseModel):
     role: Literal["user", "system", "ipython"]
     content: RawContent
 
+    # This is for RAG but likely should be absorbed into content
+    context: Optional[RawContent] = None
+
 
 class ModelOutputMessage(BaseModel):
-    role: Literal["assistant"]
+    role: Literal["assistant"] = "assistant"
     content: RawContent
     stop_reason: StopReason
     tool_calls: List[ToolCall] = Field(default_factory=list)

--- a/models/llama3/api/datatypes.py
+++ b/models/llama3/api/datatypes.py
@@ -13,11 +13,7 @@ from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 from ...datatypes import *  # noqa
 
-import base64
-import re
 from io import BytesIO
-
-from PIL import Image as PIL_Image
 
 from ...schema_utils import json_schema_type
 
@@ -28,74 +24,6 @@ class Role(Enum):
     user = "user"
     assistant = "assistant"
     ipython = "ipython"
-
-
-@json_schema_type(
-    schema={"type": "string", "format": "uri", "pattern": "^(https?://|file://|data:)"}
-)
-class URL(BaseModel):
-    uri: str
-
-    def __str__(self) -> str:
-        return self.uri
-
-
-@json_schema_type
-class ImageMedia(BaseModel):
-    image: Union[PIL_Image.Image, URL]
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-InterleavedTextMedia = Union[
-    str,
-    # Specific modalities can be placed here, but not generic attachments
-    # since models don't consume them in a generic way
-    ImageMedia,
-    List[Union[str, ImageMedia]],
-]
-
-
-def interleaved_text_media_as_str(content: InterleavedTextMedia, sep: str = " ") -> str:
-    def _process(c) -> str:
-        if isinstance(c, str):
-            return c
-        else:
-            return "<media>"
-
-    if isinstance(content, list):
-        return sep.join(_process(c) for c in content)
-    else:
-        return _process(content)
-
-
-def interleaved_text_media_localize(
-    content: InterleavedTextMedia,
-) -> InterleavedTextMedia:
-    def _localize_single(c: str | ImageMedia) -> str | ImageMedia:
-        if isinstance(c, ImageMedia):
-            # load image and return PIL version
-            img = c.image
-            if isinstance(img, URL):
-                if img.uri.startswith("file://"):
-                    img = PIL_Image.open(img.uri[len("file://") :]).convert("RGB")
-                elif img.uri.startswith("data"):
-                    match = re.match(r"data:image/(\w+);base64,(.+)", img.uri)
-                    if not match:
-                        raise ValueError("Invalid data URL format")
-                    image_type, image_data = match.groups()
-                    image_data = base64.b64decode(image_data)
-                    img = PIL_Image.open(BytesIO(image_data))
-                else:
-                    raise ValueError("Unsupported URL type")
-            return ImageMedia(image=img)
-        else:
-            return c
-
-    if isinstance(content, list):
-        return [_localize_single(c) for c in content]
-    else:
-        return _localize_single(content)
 
 
 @json_schema_type
@@ -115,23 +43,6 @@ class ToolCall(BaseModel):
     call_id: str
     tool_name: Union[BuiltinTool, str]
     arguments: Dict[str, RecursiveType]
-
-    @field_validator("tool_name", mode="before")
-    @classmethod
-    def validate_field(cls, v):
-        if isinstance(v, str):
-            try:
-                return BuiltinTool(v)
-            except ValueError:
-                return v
-        return v
-
-
-@json_schema_type
-class ToolResponse(BaseModel):
-    call_id: str
-    tool_name: Union[BuiltinTool, str]
-    content: InterleavedTextMedia
 
     @field_validator("tool_name", mode="before")
     @classmethod
@@ -170,12 +81,6 @@ class ToolDefinition(BaseModel):
 
 
 @json_schema_type
-class ToolChoice(Enum):
-    auto = "auto"
-    required = "required"
-
-
-@json_schema_type
 class ToolPromptFormat(Enum):
     """This Enum refers to the prompt format for calling custom / zero shot tools
 
@@ -206,54 +111,42 @@ class ToolPromptFormat(Enum):
 
 
 @json_schema_type
-class UserMessage(BaseModel):
-    role: Literal[Role.user.value] = Role.user.value
-    content: InterleavedTextMedia
-    context: Optional[InterleavedTextMedia] = None
-
-
-@json_schema_type
-class SystemMessage(BaseModel):
-    role: Literal[Role.system.value] = Role.system.value
-    content: InterleavedTextMedia
-
-
-@json_schema_type
-class ToolResponseMessage(BaseModel):
-    role: Literal[Role.ipython.value] = Role.ipython.value
-    # it was nice to re-use the ToolResponse type, but having all messages
-    # have a `content` type makes things nicer too
-    call_id: str
-    tool_name: Union[BuiltinTool, str]
-    content: InterleavedTextMedia
-
-
-@json_schema_type
 class StopReason(Enum):
     end_of_turn = "end_of_turn"
     end_of_message = "end_of_message"
     out_of_tokens = "out_of_tokens"
 
 
-@json_schema_type
-class TokenLogProbs(BaseModel):
-    logprobs_by_token: Dict[str, float]
+class RawMediaItem(BaseModel):
+    type: Literal["image"]
+    format: Literal["png", "jpeg", "webp"]
+    data: bytes | BytesIO
 
 
-@json_schema_type
-class CompletionMessage(BaseModel):
-    role: Literal[Role.assistant.value] = Role.assistant.value
-    content: InterleavedTextMedia
+class RawTextItem(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+RawContentItem = Annotated[
+    Union[RawTextItem, RawMediaItem], Field(discriminator="type")
+]
+
+RawContent = List[RawContentItem]
+
+
+class ModelInputMessage(BaseModel):
+    role: Literal["user", "system", "ipython"]
+    content: RawContent
+
+
+class ModelOutputMessage(BaseModel):
+    role: Literal["assistant"]
+    content: RawContent
     stop_reason: StopReason
     tool_calls: List[ToolCall] = Field(default_factory=list)
 
 
-Message = Annotated[
-    Union[
-        UserMessage,
-        SystemMessage,
-        ToolResponseMessage,
-        CompletionMessage,
-    ],
-    Field(discriminator="role"),
+ModelMessage = Annotated[
+    Union[ModelInputMessage, ModelOutputMessage], Field(discriminator="role")
 ]

--- a/models/llama3/api/test_tokenizer.py
+++ b/models/llama3/api/test_tokenizer.py
@@ -12,7 +12,7 @@ import os
 from unittest import TestCase
 
 from .chat_format import ChatFormat
-from .datatypes import SystemMessage, ToolPromptFormat, UserMessage
+from .datatypes import RawMessage, ToolPromptFormat
 from .tokenizer import Tokenizer
 
 
@@ -45,7 +45,8 @@ class TokenizerTests(TestCase):
         )
 
     def test_encode_message(self):
-        message = UserMessage(
+        message = RawMessage(
+            role="user",
             content="This is a test sentence.",
         )
         self.assertEqual(
@@ -69,10 +70,12 @@ class TokenizerTests(TestCase):
 
     def test_encode_dialog(self):
         messages = [
-            SystemMessage(
+            RawMessage(
+                role="system",
                 content="This is a test sentence.",
             ),
-            UserMessage(
+            RawMessage(
+                role="user",
                 content="This is a response.",
             ),
         ]

--- a/models/llama3/api/tool_utils.py
+++ b/models/llama3/api/tool_utils.py
@@ -100,7 +100,6 @@ def parse_python_list_for_function_calls(input_string):
 
 
 class ToolUtils:
-
     @staticmethod
     def is_builtin_tool_call(message_body: str) -> bool:
         match = re.search(ToolUtils.BUILTIN_TOOL_PATTERN, message_body)

--- a/models/llama3/prompt_templates/system_prompts.py
+++ b/models/llama3/prompt_templates/system_prompts.py
@@ -19,7 +19,6 @@ from .base import PromptTemplate, PromptTemplateGeneratorBase
 
 
 class SystemDefaultGenerator(PromptTemplateGeneratorBase):
-
     def gen(self, *args, **kwargs) -> PromptTemplate:
         template_str = textwrap.dedent(
             """
@@ -37,7 +36,6 @@ class SystemDefaultGenerator(PromptTemplateGeneratorBase):
 
 
 class BuiltinToolGenerator(PromptTemplateGeneratorBase):
-
     def _tool_breakdown(self, tools: List[ToolDefinition]):
         builtin_tools, custom_tools = [], []
         for dfn in tools:
@@ -50,7 +48,6 @@ class BuiltinToolGenerator(PromptTemplateGeneratorBase):
 
     def gen(self, tools: List[ToolDefinition]) -> PromptTemplate:
         builtin_tools, custom_tools = self._tool_breakdown(tools)
-        data = []
         template_str = textwrap.dedent(
             """
             {% if builtin_tools or custom_tools -%}
@@ -86,7 +83,6 @@ class BuiltinToolGenerator(PromptTemplateGeneratorBase):
 
 
 class JsonCustomToolGenerator(PromptTemplateGeneratorBase):
-
     def gen(self, custom_tools: List[ToolDefinition]) -> PromptTemplate:
         template_str = textwrap.dedent(
             """
@@ -157,7 +153,6 @@ class JsonCustomToolGenerator(PromptTemplateGeneratorBase):
 
 
 class FunctionTagCustomToolGenerator(PromptTemplateGeneratorBase):
-
     def gen(self, custom_tools: List[ToolDefinition]) -> PromptTemplate:
         template_str = textwrap.dedent(
             """
@@ -220,7 +215,6 @@ class FunctionTagCustomToolGenerator(PromptTemplateGeneratorBase):
 
 
 class PythonListCustomToolGenerator(PromptTemplateGeneratorBase):  # noqa: N801
-
     def gen(self, custom_tools: List[ToolDefinition]) -> PromptTemplate:
         template_str = textwrap.dedent(
             """

--- a/models/llama3/reference_impl/generation.py
+++ b/models/llama3/reference_impl/generation.py
@@ -33,13 +33,7 @@ from termcolor import cprint
 
 from ..api.args import ModelArgs
 from ..api.chat_format import ChatFormat, LLMInput
-from ..api.datatypes import (
-    ModelMessage,
-    ModelOutputMessage,
-    RawContent,
-    StopReason,
-    ToolPromptFormat,
-)
+from ..api.datatypes import RawContent, RawMessage, StopReason, ToolPromptFormat
 from ..api.tokenizer import Tokenizer
 from .model import Transformer
 
@@ -53,7 +47,7 @@ class CompletionPrediction:
 
 @dataclass
 class ChatPrediction:
-    generation: ModelOutputMessage
+    generation: RawMessage
     decoded_tokens: Optional[List[str]] = None
     logprobs: Optional[List[List[float]]] = None
 
@@ -347,7 +341,7 @@ class Llama:
 
     def chat_completion(
         self,
-        messages: List[ModelMessage],
+        messages: List[RawMessage],
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,
@@ -403,7 +397,7 @@ class Llama:
 
     def chat_completion_raw(
         self,
-        messages: List[ModelMessage],
+        messages: List[RawMessage],
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,

--- a/models/llama3/reference_impl/generation.py
+++ b/models/llama3/reference_impl/generation.py
@@ -32,11 +32,11 @@ from fairscale.nn.model_parallel.initialize import (
 from termcolor import cprint
 
 from ..api.args import ModelArgs
-from ..api.chat_format import ChatFormat, ModelInput
+from ..api.chat_format import ChatFormat, LLMInput
 from ..api.datatypes import (
-    CompletionMessage,
-    InterleavedTextMedia,
-    Message,
+    ModelMessage,
+    ModelOutputMessage,
+    RawContent,
     StopReason,
     ToolPromptFormat,
 )
@@ -53,7 +53,7 @@ class CompletionPrediction:
 
 @dataclass
 class ChatPrediction:
-    generation: CompletionMessage
+    generation: ModelOutputMessage
     decoded_tokens: Optional[List[str]] = None
     logprobs: Optional[List[List[float]]] = None
 
@@ -163,7 +163,7 @@ class Llama:
     @torch.inference_mode()
     def generate(
         self,
-        model_input: ModelInput,
+        model_input: LLMInput,
         max_gen_len: int,
         temperature: float = 0.6,
         top_p: float = 0.9,
@@ -303,7 +303,7 @@ class Llama:
 
     def text_completion(
         self,
-        content: InterleavedTextMedia,
+        content: RawContent,
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,
@@ -347,7 +347,7 @@ class Llama:
 
     def chat_completion(
         self,
-        messages: List[Message],
+        messages: List[ModelMessage],
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,
@@ -403,7 +403,7 @@ class Llama:
 
     def chat_completion_raw(
         self,
-        messages: List[Message],
+        messages: List[ModelMessage],
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,
@@ -432,7 +432,7 @@ class Llama:
 
     def text_completion_raw(
         self,
-        content: InterleavedTextMedia,
+        content: RawContent,
         temperature: float = 0.6,
         top_p: float = 0.9,
         max_gen_len: Optional[int] = None,
@@ -448,8 +448,6 @@ class Llama:
         input_tokens = model_input.tokens
 
         output_tokens = []
-        token_logprobs = []
-        decoded_tokens = []
         for result in self.generate(
             model_input=model_input,
             max_gen_len=max_gen_len,

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -12,10 +12,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from llama_models.llama3.api.datatypes import ImageMedia, SystemMessage, UserMessage
+from llama_models.llama3.api.datatypes import RawMediaItem, RawMessage, RawTextItem
 
 from llama_models.llama3.reference_impl.generation import Llama
-from PIL import Image as PIL_Image
 
 THIS_DIR = Path(__file__).parent
 
@@ -37,7 +36,6 @@ def build_generator(env_var: str):
 
 
 class TestTextModelInference(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.generator = build_generator("TEXT_MODEL_CHECKPOINT_DIR")
@@ -45,14 +43,14 @@ class TestTextModelInference(unittest.TestCase):
     def test_run_generation(self):
         dialogs = [
             [
-                SystemMessage(content="Always answer with Haiku"),
-                UserMessage(content="I am going to Paris, what should I see?"),
+                RawMessage(role="system", content="Always answer with Haiku"),
+                RawMessage(
+                    role="user", content="I am going to Paris, what should I see?"
+                ),
             ],
             [
-                SystemMessage(
-                    content="Always answer with emojis",
-                ),
-                UserMessage(content="How to go from Beijing to NY?"),
+                RawMessage(role="system", content="Always answer with emojis"),
+                RawMessage(role="user", content="How to go from Beijing to NY?"),
             ],
         ]
         for dialog in dialogs:
@@ -71,7 +69,6 @@ class TestTextModelInference(unittest.TestCase):
 
 
 class TestVisionModelInference(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.generator = build_generator("VISION_MODEL_CHECKPOINT_DIR")
@@ -82,21 +79,23 @@ class TestVisionModelInference(unittest.TestCase):
         with open(
             THIS_DIR.parent.parent.parent / "scripts/resources/dog.jpg", "rb"
         ) as f:
-            img = PIL_Image.open(f).convert("RGB")
+            img = f.read()
 
         dialogs = [
             [
-                UserMessage(
+                RawMessage(
+                    role="user",
                     content=[
-                        ImageMedia(image=img),
-                        "Describe this image in two sentences",
+                        RawMediaItem(data=img),
+                        RawTextItem(text="Describe this image in two sentences"),
                     ],
                 )
             ],
             [
-                UserMessage(
-                    content="what is the recipe of mayonnaise in two sentences?"
-                ),
+                RawMessage(
+                    role="user",
+                    content="what is the recipe of mayonnaise in two sentences?",
+                )
             ],
         ]
 

--- a/models/llama3_1/prompts.py
+++ b/models/llama3_1/prompts.py
@@ -7,7 +7,14 @@
 
 import textwrap
 from typing import List
-from ..llama3.api.datatypes import *  # noqa: F403
+
+from ..llama3.api.datatypes import (
+    BuiltinTool,
+    RawMessage,
+    StopReason,
+    ToolCall,
+    ToolPromptFormat,
+)
 from ..prompt_format import (
     llama3_1_builtin_tool_call_dialog,
     llama3_1_custom_tool_call_dialog,
@@ -104,8 +111,11 @@ def usecases() -> List[UseCase | str]:
             description="Here is a regular multi-turn user assistant conversation and how its formatted.",
             dialogs=[
                 [
-                    SystemMessage(content="You are a helpful assistant"),
-                    UserMessage(content="Answer who are you in the form of jeopardy?"),
+                    RawMessage(role="system", content="You are a helpful assistant"),
+                    RawMessage(
+                        role="user",
+                        content="Answer who are you in the form of jeopardy?",
+                    ),
                 ]
             ],
             notes="",
@@ -141,9 +151,10 @@ def usecases() -> List[UseCase | str]:
             description="Here is an actual example of model responding with code",
             dialogs=[
                 [
-                    SystemMessage(content="Environment: ipython"),
-                    UserMessage(
-                        content="Write code to check if number is prime, use that to see if the number 7 is prime"
+                    RawMessage(role="system", content="Environment: ipython"),
+                    RawMessage(
+                        role="user",
+                        content="Write code to check if number is prime, use that to see if the number 7 is prime",
                     ),
                 ],
             ],
@@ -159,11 +170,13 @@ def usecases() -> List[UseCase | str]:
             description="Here is a full interaction with the built-in tools including the tool response and the final assistant response.",
             dialogs=[
                 [
-                    SystemMessage(
-                        content="Environment: ipython\nTools: brave_search, wolfram_alpha\n"
+                    RawMessage(
+                        role="system",
+                        content="Environment: ipython\nTools: brave_search, wolfram_alpha\n",
                     ),
-                    UserMessage(content="What is the 100th decimal of pi?"),
-                    CompletionMessage(
+                    RawMessage(role="user", content="What is the 100th decimal of pi?"),
+                    RawMessage(
+                        role="assistant",
                         content="",
                         stop_reason=StopReason.end_of_message,
                         tool_calls=[
@@ -174,9 +187,8 @@ def usecases() -> List[UseCase | str]:
                             )
                         ],
                     ),
-                    ToolResponseMessage(
-                        call_id="wolfram_alpha_id",
-                        tool_name=BuiltinTool.wolfram_alpha,
+                    RawMessage(
+                        role="ipython",
                         content=wolfram_alpha_response(),
                     ),
                 ],

--- a/models/llama3_2/prompts_text.py
+++ b/models/llama3_2/prompts_text.py
@@ -6,7 +6,8 @@
 # the top-level of this source tree.
 import json
 import textwrap
-from ..llama3.api.datatypes import *  # noqa: F403
+
+from ..llama3.api.datatypes import RawMessage, StopReason, ToolCall, ToolPromptFormat
 from ..prompt_format import (
     llama3_1_builtin_code_interpreter_dialog,
     TextCompletionContent,
@@ -99,8 +100,8 @@ def usecases():
             description="Here is a regular multi-turn user assistant conversation and how its formatted.",
             dialogs=[
                 [
-                    SystemMessage(content="You are a helpful assistant"),
-                    UserMessage(content="Who are you?"),
+                    RawMessage(role="system", content="You are a helpful assistant"),
+                    RawMessage(role="user", content="Who are you?"),
                 ]
             ],
             notes="This format is unchanged from Llama3.1",
@@ -119,8 +120,10 @@ def usecases():
             dialogs=[
                 # Zero shot tool calls as system message
                 [
-                    SystemMessage(content=system_tool_call()),
-                    UserMessage(content="What is the weather in SF and Seattle?"),
+                    RawMessage(role="system", content=system_tool_call()),
+                    RawMessage(
+                        role="user", content="What is the weather in SF and Seattle?"
+                    ),
                 ],
             ],
             notes=textwrap.dedent(
@@ -140,7 +143,7 @@ def usecases():
             dialogs=[
                 # Zero shot tool call as user message
                 [
-                    UserMessage(content=user_tool_call()),
+                    RawMessage(role="user", content=user_tool_call()),
                 ],
             ],
             notes=textwrap.dedent(
@@ -175,9 +178,10 @@ def usecases():
             ),
             dialogs=[
                 [
-                    SystemMessage(content=system_tool_call()),
-                    UserMessage(content="What is the weather in SF?"),
-                    CompletionMessage(
+                    RawMessage(role="system", content=system_tool_call()),
+                    RawMessage(role="user", content="What is the weather in SF?"),
+                    RawMessage(
+                        role="assistant",
                         content="",
                         stop_reason=StopReason.end_of_turn,
                         tool_calls=[
@@ -191,9 +195,8 @@ def usecases():
                             )
                         ],
                     ),
-                    ToolResponseMessage(
-                        call_id="call",
-                        tool_name="get_weather",
+                    RawMessage(
+                        role="ipython",
                         content=json.dumps("25 C"),
                     ),
                 ],

--- a/models/llama3_2/prompts_vision.py
+++ b/models/llama3_2/prompts_vision.py
@@ -8,9 +8,7 @@
 import textwrap
 from pathlib import Path
 
-from PIL import Image as PIL_Image
-
-from ..llama3.api.datatypes import *  # noqa: F403
+from ..llama3.api.datatypes import RawMediaItem, RawMessage, RawTextItem
 from ..prompt_format import (
     llama3_1_builtin_tool_call_dialog,
     # llama3_1_builtin_tool_call_with_image_dialog,
@@ -23,7 +21,7 @@ from ..prompt_format import (
 def usecases():
     this_dir = Path(__file__).parent.parent.resolve()
     with open(this_dir / "scripts/resources/dog.jpg", "rb") as f:
-        img = PIL_Image.open(f).convert("RGB")
+        img = f.read()
 
     return [
         llama3_2_user_assistant_conversation(),
@@ -32,10 +30,11 @@ def usecases():
             description="This example shows how to pass and image to the model as part of the messages.",
             dialogs=[
                 [
-                    UserMessage(
+                    RawMessage(
+                        role="user",
                         content=[
-                            ImageMedia(image=img),
-                            "Describe this image in two sentences",
+                            RawMediaItem(data=img),
+                            RawTextItem(text="Describe this image in two sentences"),
                         ],
                     )
                 ],
@@ -115,8 +114,8 @@ def usecases():
             dialogs=[
                 TextCompletionContent(
                     content=[
-                        ImageMedia(image=img),
-                        "If I had to write a haiku for this one",
+                        RawMediaItem(data=img),
+                        RawTextItem(text="If I had to write a haiku for this one"),
                     ]
                 ),
             ],

--- a/models/llama3_3/prompts.py
+++ b/models/llama3_3/prompts.py
@@ -7,7 +7,14 @@
 
 import textwrap
 from typing import List
-from ..llama3.api.datatypes import *  # noqa: F403
+
+from ..llama3.api.datatypes import (
+    BuiltinTool,
+    RawMessage,
+    StopReason,
+    ToolCall,
+    ToolPromptFormat,
+)
 from ..prompt_format import (
     llama3_1_builtin_tool_call_dialog,
     llama3_1_custom_tool_call_dialog,
@@ -104,8 +111,11 @@ def usecases() -> List[UseCase | str]:
             description="Here is a regular multi-turn user assistant conversation and how its formatted.",
             dialogs=[
                 [
-                    SystemMessage(content="You are a helpful assistant"),
-                    UserMessage(content="Answer who are you in the form of jeopardy?"),
+                    RawMessage(role="system", content="You are a helpful assistant"),
+                    RawMessage(
+                        role="user",
+                        content="Answer who are you in the form of jeopardy?",
+                    ),
                 ]
             ],
             notes="",
@@ -141,9 +151,10 @@ def usecases() -> List[UseCase | str]:
             description="Here is an actual example of model responding with code",
             dialogs=[
                 [
-                    SystemMessage(content="Environment: ipython"),
-                    UserMessage(
-                        content="Write code to check if number is prime, use that to see if the number 7 is prime"
+                    RawMessage(role="system", content="Environment: ipython"),
+                    RawMessage(
+                        role="user",
+                        content="Write code to check if number is prime, use that to see if the number 7 is prime",
                     ),
                 ],
             ],
@@ -159,11 +170,12 @@ def usecases() -> List[UseCase | str]:
             description="Here is a full interaction with the built-in tools including the tool response and the final assistant response.",
             dialogs=[
                 [
-                    SystemMessage(
-                        content="Environment: ipython\nTools: brave_search, wolfram_alpha\n"
+                    RawMessage(
+                        role="system",
+                        content="Environment: ipython\nTools: brave_search, wolfram_alpha\n",
                     ),
-                    UserMessage(content="What is the 100th decimal of pi?"),
-                    CompletionMessage(
+                    RawMessage(role="user", content="What is the 100th decimal of pi?"),
+                    RawMessage(
                         content="",
                         stop_reason=StopReason.end_of_message,
                         tool_calls=[
@@ -174,9 +186,8 @@ def usecases() -> List[UseCase | str]:
                             )
                         ],
                     ),
-                    ToolResponseMessage(
-                        call_id="wolfram_alpha_id",
-                        tool_name=BuiltinTool.wolfram_alpha,
+                    RawMessage(
+                        role="ipython",
                         content=wolfram_alpha_response(),
                     ),
                 ],

--- a/models/scripts/example_chat_completion.py
+++ b/models/scripts/example_chat_completion.py
@@ -13,10 +13,9 @@ from typing import Optional
 import fire
 
 from llama_models.llama3.api.datatypes import (
-    CompletionMessage,
+    ModelInputMessage,
+    ModelOutputMessage,
     StopReason,
-    SystemMessage,
-    UserMessage,
 )
 
 from llama_models.llama3.reference_impl.generation import Llama
@@ -48,10 +47,13 @@ def run_main(
     )
 
     dialogs = [
-        [UserMessage(content="what is the recipe of mayonnaise?")],
+        [ModelInputMessage(role="user", content="what is the recipe of mayonnaise?")],
         [
-            UserMessage(content="I am going to Paris, what should I see?"),
-            CompletionMessage(
+            ModelInputMessage(
+                role="user",
+                content="I am going to Paris, what should I see?",
+            ),
+            ModelOutputMessage(
                 content="""\
 Paris, the capital of France, is known for its stunning architecture, art museums, historical landmarks, and romantic atmosphere. Here are some of the top attractions to see in Paris:
 
@@ -62,17 +64,17 @@ Paris, the capital of France, is known for its stunning architecture, art museum
 These are just a few of the many attractions that Paris has to offer. With so much to see and do, it's no wonder that Paris is one of the most popular tourist destinations in the world.""",
                 stop_reason=StopReason.end_of_turn,
             ),
-            UserMessage(content="What is so great about #1?"),
+            ModelInputMessage(role="user", content="What is so great about #1?"),
         ],
         [
-            SystemMessage(content="Always answer with Haiku"),
-            UserMessage(content="I am going to Paris, what should I see?"),
-        ],
-        [
-            SystemMessage(
-                content="Always answer with emojis",
+            ModelInputMessage(role="system", content="Always answer with Haiku"),
+            ModelInputMessage(
+                role="user", content="I am going to Paris, what should I see?"
             ),
-            UserMessage(content="How to go from Beijing to NY?"),
+        ],
+        [
+            ModelInputMessage(role="system", content="Always answer with emojis"),
+            ModelInputMessage(role="user", content="How to go from Beijing to NY?"),
         ],
     ]
     for dialog in dialogs:

--- a/models/scripts/example_chat_completion.py
+++ b/models/scripts/example_chat_completion.py
@@ -12,11 +12,7 @@ from typing import Optional
 
 import fire
 
-from llama_models.llama3.api.datatypes import (
-    ModelInputMessage,
-    ModelOutputMessage,
-    StopReason,
-)
+from llama_models.llama3.api.datatypes import RawMessage, StopReason
 
 from llama_models.llama3.reference_impl.generation import Llama
 
@@ -47,13 +43,14 @@ def run_main(
     )
 
     dialogs = [
-        [ModelInputMessage(role="user", content="what is the recipe of mayonnaise?")],
+        [RawMessage(role="user", content="what is the recipe of mayonnaise?")],
         [
-            ModelInputMessage(
+            RawMessage(
                 role="user",
                 content="I am going to Paris, what should I see?",
             ),
-            ModelOutputMessage(
+            RawMessage(
+                role="assistant",
                 content="""\
 Paris, the capital of France, is known for its stunning architecture, art museums, historical landmarks, and romantic atmosphere. Here are some of the top attractions to see in Paris:
 
@@ -64,17 +61,15 @@ Paris, the capital of France, is known for its stunning architecture, art museum
 These are just a few of the many attractions that Paris has to offer. With so much to see and do, it's no wonder that Paris is one of the most popular tourist destinations in the world.""",
                 stop_reason=StopReason.end_of_turn,
             ),
-            ModelInputMessage(role="user", content="What is so great about #1?"),
+            RawMessage(role="user", content="What is so great about #1?"),
         ],
         [
-            ModelInputMessage(role="system", content="Always answer with Haiku"),
-            ModelInputMessage(
-                role="user", content="I am going to Paris, what should I see?"
-            ),
+            RawMessage(role="system", content="Always answer with Haiku"),
+            RawMessage(role="user", content="I am going to Paris, what should I see?"),
         ],
         [
-            ModelInputMessage(role="system", content="Always answer with emojis"),
-            ModelInputMessage(role="user", content="How to go from Beijing to NY?"),
+            RawMessage(role="system", content="Always answer with emojis"),
+            RawMessage(role="user", content="How to go from Beijing to NY?"),
         ],
     ]
     for dialog in dialogs:

--- a/models/scripts/multimodal_example_chat_completion.py
+++ b/models/scripts/multimodal_example_chat_completion.py
@@ -8,15 +8,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
+from io import BytesIO
+from pathlib import Path
 from typing import Optional
 
 import fire
-
-from llama_models.llama3.api.datatypes import ImageMedia, UserMessage
+from llama_models.llama3.api.datatypes import ModelInputMessage, RawMediaItem
 
 from llama_models.llama3.reference_impl.generation import Llama
 
-from PIL import Image as PIL_Image
+THIS_DIR = Path(__file__).parent
 
 
 def run_main(
@@ -38,13 +39,14 @@ def run_main(
     # image understanding
     dialogs = []
     with open(THIS_DIR / "resources/dog.jpg", "rb") as f:
-        img = PIL_Image.open(f).convert("RGB")
+        img = f.read()
 
     dialogs = [
         [
-            UserMessage(
+            ModelInputMessage(
+                role="user",
                 content=[
-                    ImageMedia(image=img),
+                    RawMediaItem(type="image", data=BytesIO(img)),
                     "Describe this image in two sentences",
                 ],
             )
@@ -52,7 +54,12 @@ def run_main(
     ]
     # text only
     dialogs += [
-        [UserMessage(content="what is the recipe of mayonnaise in two sentences?")],
+        [
+            ModelInputMessage(
+                role="user",
+                content="what is the recipe of mayonnaise in two sentences?",
+            )
+        ],
     ]
 
     for dialog in dialogs:

--- a/models/scripts/multimodal_example_chat_completion.py
+++ b/models/scripts/multimodal_example_chat_completion.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from typing import Optional
 
 import fire
-from llama_models.llama3.api.datatypes import ModelInputMessage, RawMediaItem
+from llama_models.llama3.api.datatypes import (
+    ModelInputMessage,
+    RawMediaItem,
+    RawTextItem,
+)
 
 from llama_models.llama3.reference_impl.generation import Llama
 
@@ -46,8 +50,8 @@ def run_main(
             ModelInputMessage(
                 role="user",
                 content=[
-                    RawMediaItem(type="image", data=BytesIO(img)),
-                    "Describe this image in two sentences",
+                    RawMediaItem(data=BytesIO(img)),
+                    RawTextItem(text="Describe this image in two sentences"),
                 ],
             )
         ],

--- a/models/scripts/multimodal_example_chat_completion.py
+++ b/models/scripts/multimodal_example_chat_completion.py
@@ -13,11 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 import fire
-from llama_models.llama3.api.datatypes import (
-    ModelInputMessage,
-    RawMediaItem,
-    RawTextItem,
-)
+from llama_models.llama3.api.datatypes import RawMediaItem, RawMessage, RawTextItem
 
 from llama_models.llama3.reference_impl.generation import Llama
 
@@ -47,7 +43,7 @@ def run_main(
 
     dialogs = [
         [
-            ModelInputMessage(
+            RawMessage(
                 role="user",
                 content=[
                     RawMediaItem(data=BytesIO(img)),
@@ -59,7 +55,7 @@ def run_main(
     # text only
     dialogs += [
         [
-            ModelInputMessage(
+            RawMessage(
                 role="user",
                 content="what is the recipe of mayonnaise in two sentences?",
             )

--- a/models/scripts/multimodal_example_text_completion.py
+++ b/models/scripts/multimodal_example_text_completion.py
@@ -8,16 +8,19 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed in accordance with the terms of the Llama 3 Community License Agreement.
 
+from io import BytesIO
+from pathlib import Path
 from typing import Optional
 
 import fire
-
-from llama_models.llama3.api.datatypes import ImageMedia
+from llama_models.llama3.api.datatypes import RawMediaItem
 
 from llama_models.llama3.reference_impl.generation import Llama
 
-from PIL import Image as PIL_Image
 from termcolor import cprint
+
+
+THIS_DIR = Path(__file__).parent
 
 
 def run_main(
@@ -37,17 +40,14 @@ def run_main(
     )
 
     with open(THIS_DIR / "resources/dog.jpg", "rb") as f:
-        img = PIL_Image.open(f).convert("RGB")
-
-    with open(THIS_DIR / "resources/pasta.jpeg", "rb") as f:
-        img2 = PIL_Image.open(f).convert("RGB")
+        img = f.read()
 
     interleaved_contents = [
         # text only
         "The color of the sky is blue but sometimes it can also be",
         # image understanding
         [
-            ImageMedia(image=img),
+            RawMediaItem(type="image", data=BytesIO(img)),
             "If I had to write a haiku for this one",
         ],
     ]


### PR DESCRIPTION
## What this PR does
This is a long-pending change and particularly important to get done now. 

Specifically:
- we cannot "localize" (aka download) any URLs from media attachments anywhere near our modeling code. it must be done upwards in the stack or in other utilities
- the PIL.Image is infesting all our APIs and that cannot be right at all. we need a standard `{ type: "image", image_url: "<...>" }` which is more extensible
- this essentially argues for separating Model-related Message types (don't have too much structure here) and the API-level Message types. As a result of this PR, `UserMessage`, etc. are moved completely to `llama-stack`.

This PR will have a substantial accompanying PR in llama-stack as well.

## Test Plan
Ran the sole pytest test for model running:
```
TEXT_MODEL_CHECKPOINT_DIR=~/.llama/checkpoints/Llama3.2-3B-Instruct \
  PYTHONPATH=. \
  pytest models/llama3/tests/api/test_generation.py
```

Ran the example scripts:
```
PYTHONPATH=. \
   torchrun \
   llama_models/scripts/multimodal_example_chat_completion.py ~/.llama/checkpoints/Llama3.2-11B-Vision-Instruct
```