### PR TITLE
[CICD] github workflow for nightly testpypi llama-models package

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,7 +1,7 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  workflow_dispatch:  # Keep manual trigger
+  push:  # Keep manual trigger
     inputs:
       rc_version:
         description: 'RC version number (e.g., 1, 2, 3)'

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,6 +2,11 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on:
   workflow_dispatch:  # Keep manual trigger
+  inputs:
+    rc_version:
+      description: 'RC version number (e.g., 1, 2, 3)'
+      required: true
+      type: string
   schedule:
     - cron: "0 0 * * *"  # Run every day at midnight
 
@@ -22,6 +27,10 @@ jobs:
       run: |
         # Assuming your version is in setup.py or pyproject.toml
         sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}"/' setup.py
+    - name: Update version for manual RC
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        sed -i 's/version="\([^"]*\)"/version="\1rc${{ inputs.rc_version }}"/' setup.py
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,14 +1,15 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  workflow_dispatch:  # Keep manual trigger
-    inputs:
-      rc_version:
-        description: 'RC version number (e.g., 1, 2, 3)'
-        required: true
-        type: string
-  schedule:
-    - cron: "0 0 * * *"  # Run every day at midnight
+  push
+  # workflow_dispatch:  # Keep manual trigger
+  #   inputs:
+  #     rc_version:
+  #       description: 'RC version number (e.g., 1, 2, 3)'
+  #       required: true
+  #       type: string
+  # schedule:
+  #   - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   build:
@@ -23,10 +24,10 @@ jobs:
       id: date
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
     - name: Update version for nightly
-      if: github.event_name == 'schedule'
+      # if: github.event_name == 'schedule'
       run: |
         # Assuming your version is in setup.py or pyproject.toml
-        sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}"/' setup.py
+        sed -i 's/version="\([^"]*\)"/version="\1.dev${{ steps.date.outputs.date }}"/' setup.py
     - name: Update version for manual RC
       if: github.event_name == 'push'
       run: |

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -29,7 +29,7 @@ jobs:
         # Assuming your version is in setup.py or pyproject.toml
         sed -i 's/version="\([^"]*\)"/version="\1.dev${{ steps.date.outputs.date }}"/' setup.py
     - name: Update version for manual RC
-      if: github.event_name == 'push'
+      if: github.event_name == 'workflow_dispatch'
       run: |
         sed -i 's/version="\([^"]*\)"/version="\1rc${{ inputs.rc_version }}"/' setup.py
     - name: Set up Python

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,10 +1,9 @@
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on:
-  push
-  # workflow_dispatch:  # Keep manual trigger
-  # schedule:
-  #   - cron: "0 0 * * *"  # Run every day at midnight
+  workflow_dispatch:  # Keep manual trigger
+  schedule:
+    - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   build:
@@ -19,7 +18,7 @@ jobs:
       id: date
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
     - name: Update version for nightly
-      # if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule'
       run: |
         # Assuming your version is in setup.py or pyproject.toml
         sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}"/' setup.py

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
   workflow_dispatch:  # Keep manual trigger

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,15 +1,14 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  push
-  # workflow_dispatch:  # Keep manual trigger
-  #   inputs:
-  #     rc_version:
-  #       description: 'RC version number (e.g., 1, 2, 3)'
-  #       required: true
-  #       type: string
-  # schedule:
-  #   - cron: "0 0 * * *"  # Run every day at midnight
+  workflow_dispatch:  # Keep manual trigger
+    inputs:
+      rc_version:
+        description: 'RC version number (e.g., 1, 2, 3)'
+        required: true
+        type: string
+  schedule:
+    - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   build:
@@ -24,7 +23,7 @@ jobs:
       id: date
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
     - name: Update version for nightly
-      # if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule'
       run: |
         # Assuming your version is in setup.py or pyproject.toml
         sed -i 's/version="\([^"]*\)"/version="\1.dev${{ steps.date.outputs.date }}"/' setup.py

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -18,14 +18,11 @@ jobs:
     - name: Get date
       id: date
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-    - name: Get short SHA
-      id: sha
-      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Update version for nightly
-      if: github.event_name == 'schedule'
+      # if: github.event_name == 'schedule'
       run: |
         # Assuming your version is in setup.py or pyproject.toml
-        sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}+${{ steps.sha.outputs.sha }}"/' setup.py
+        sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}"/' setup.py
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -52,7 +49,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/llama-stack-models
+      url: https://test.pypi.org/p/llama-models
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     environment:
-      name: testpypi
+      name: testrelease
       url: https://test.pypi.org/p/llama-models
 
     permissions:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -28,7 +28,7 @@ jobs:
         # Assuming your version is in setup.py or pyproject.toml
         sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}"/' setup.py
     - name: Update version for manual RC
-      if: github.event_name == 'workflow_dispatch'
+      if: github.event_name == 'push'
       run: |
         sed -i 's/version="\([^"]*\)"/version="\1rc${{ inputs.rc_version }}"/' setup.py
     - name: Set up Python

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,11 +2,11 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
 on:
   workflow_dispatch:  # Keep manual trigger
-  inputs:
-    rc_version:
-      description: 'RC version number (e.g., 1, 2, 3)'
-      required: true
-      type: string
+    inputs:
+      rc_version:
+        description: 'RC version number (e.g., 1, 2, 3)'
+        required: true
+        type: string
   schedule:
     - cron: "0 0 * * *"  # Run every day at midnight
 

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,69 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on:
+  push
+  # workflow_dispatch:  # Keep manual trigger
+  # schedule:
+  #   - cron: "0 0 * * *"  # Run every day at midnight
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Get date
+      id: date
+      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+    - name: Get short SHA
+      id: sha
+      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Update version for nightly
+      if: github.event_name == 'schedule'
+      run: |
+        # Assuming your version is in setup.py or pyproject.toml
+        sed -i 's/version="\([^"]*\)"/version="\1rc${{ steps.date.outputs.date }}+${{ steps.sha.outputs.sha }}"/' setup.py
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/llama-stack-models
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,7 +1,7 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
-  push:  # Keep manual trigger
+  workflow_dispatch:  # Keep manual trigger
     inputs:
       rc_version:
         description: 'RC version number (e.g., 1, 2, 3)'


### PR DESCRIPTION
# What
- as title
- trusted publisher: https://test.pypi.org/manage/project/llama-models/settings/publishing/
<img width="656" alt="image" src="https://github.com/user-attachments/assets/731f7e15-4b8c-487c-bb38-74f72c494b49" />

To Use

1. Nightly triggers and make a <VERSION>.dev<DATE> package to (e.g. https://test.pypi.org/project/llama-models/0.0.63.dev20250109/)

2. Manual trigger make a <VERSION>rc<X> package to test.pypi, where <X> will be input of workflow

<img width="1621" alt="image" src="https://github.com/user-attachments/assets/e31d1331-06da-4064-a8ef-34c9488fd2c5" />


# Test
- Test Workflow: https://github.com/meta-llama/llama-models/actions/runs/12698757887/job/35397937186?pr=256
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/419d7294-7381-490d-affe-c4c4c1032321" />

- Test Package: https://test.pypi.org/project/llama-models/0.0.63rc20250109/

