### PR TITLE
[CICD] change nightly schedule to repository_dispatch

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,14 +1,15 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
+  repository_dispatch:  # on trigger from llama-stack
+    types: [build-models-package]
+  
   workflow_dispatch:  # Keep manual trigger
     inputs:
       rc_version:
         description: 'RC version number (e.g., 1, 2, 3)'
         required: true
         type: string
-  schedule:
-    - cron: "0 0 * * *"  # Run every day at midnight
 
 jobs:
   build:
@@ -22,11 +23,10 @@ jobs:
     - name: Get date
       id: date
       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-    - name: Update version for nightly
-      if: github.event_name == 'schedule'
+    - name: Update version for repository_dispatch
+      if: github.event_name == 'repository_dispatch' && github.event.client_payload.source == 'llama-stack-nightly'
       run: |
-        # Assuming your version is in setup.py or pyproject.toml
-        sed -i 's/version="\([^"]*\)"/version="\1.dev${{ steps.date.outputs.date }}"/' setup.py
+        sed -i 's/version="\([^"]*\)"/version="\1${{ github.event.client_payload.version }}"/' setup.py
     - name: Update version for manual RC
       if: github.event_name == 'workflow_dispatch'
       run: |


### PR DESCRIPTION
- Make llama-models package build triggered by llama-stack build

- Tested in https://github.com/meta-llama/llama-stack/pull/734