### PR TITLE
Update prompt_format.md

### DIFF
--- a/models/llama3_3/prompt_format.md
+++ b/models/llama3_3/prompt_format.md
@@ -203,7 +203,7 @@ What is the 100th decimal of pi?<|eot_id|><|start_header_id|>assistant<|end_head
         ]
     }
 }
-<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+<|eom_id|><|start_header_id|>assistant<|end_header_id|>
 
 
 ```


### PR DESCRIPTION
According to the doc, `eot_id` should only appear at the end of the turn, including the assistant final answer.