### PR TITLE
clarifies instructions for utilizing the base model  script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ CHECKPOINT_DIR=~/.llama/checkpoints/Meta-Llama3.1-8B-Instruct
 PYTHONPATH=$(git rev-parse --show-toplevel) torchrun llama_models/scripts/example_chat_completion.py $CHECKPOINT_DIR
 ```
 
-The above script should be used with an Instruct (Chat) model. For a Base model, use the script `llama_models/scripts/example_text_completion.py`. Note that you can use these scripts with both Llama3 and Llama3.1 series of models.
+The above script should be used with an Instruct (Chat) model. For a Base model, update the `CHECKPOINT_DIR` path and use the script `llama_models/scripts/example_text_completion.py`. Note that you can use these scripts with both Llama3 and Llama3.1 series of models.
 
 For running larger models with tensor parallelism, you should modify as:
 ```bash


### PR DESCRIPTION
if you are using a model besides "Meta-Llama3.1-8B-Instruct", the path of "CHECKPOINT_DIR=~/.llama/checkpoints/Meta-Llama3.1-8B-Instruct" needs to be updated in order for the model to run 

![image](https://github.com/user-attachments/assets/85ba8e35-23c1-4521-8b52-026dbc3b9564)
