### PR TITLE
Update Sampling `strategy` to be a union instead of enum

### DIFF
--- a/models/sku_list.py
+++ b/models/sku_list.py
@@ -14,7 +14,7 @@ from .datatypes import (
     CoreModelId,
     Model,
     SamplingParams,
-    SamplingStrategy,
+    TopPSamplingStrategy,
 )
 
 LLAMA2_VOCAB_SIZE = 32000
@@ -41,9 +41,10 @@ def all_registered_models() -> List[Model]:
 
 def recommended_sampling_params() -> SamplingParams:
     return SamplingParams(
-        strategy=SamplingStrategy.top_p,
-        temperature=1.0,
-        top_p=0.9,
+        strategy=TopPSamplingStrategy(
+            temperature=1.0,
+            top_p=0.9,
+        )
     )
 
 


### PR DESCRIPTION
Earlier sampling strategy was an enum -- `greedy`, `top_p`, `top_k` and would take params like temperature, top_p, top_k, irrespective of strategy. However, top_p is not required for top_k strategy and so on thus polluting the param.

Hence, this PR instead introduces a union for each sampling strategy with the relevant params. 

Tested using -- 
```
llama model describe -m Llama3.2-3B-Instruct
``` 
which reads these params and prints the correct format as shown below 
```
+-----------------------------+----------------------------------+
| Model                       | Llama3.2-3B-Instruct             |
+-----------------------------+----------------------------------+
| Hugging Face ID             | meta-llama/Llama-3.2-3B-Instruct |
+-----------------------------+----------------------------------+
| Description                 | Llama 3.2 3b instruct model      |
+-----------------------------+----------------------------------+
| Context Length              | 128K tokens                      |
+-----------------------------+----------------------------------+
| Weights format              | bf16                             |
+-----------------------------+----------------------------------+
| Model params.json           | {                                |
|                             |     "dim": 3072,                 |
|                             |     "n_layers": 28,              |
|                             |     "n_heads": 24,               |
|                             |     "n_kv_heads": 8,             |
|                             |     "vocab_size": 128256,        |
|                             |     "ffn_dim_multiplier": 1.0,   |
|                             |     "multiple_of": 256,          |
|                             |     "norm_eps": 1e-05,           |
|                             |     "rope_theta": 500000.0,      |
|                             |     "use_scaled_rope": true      |
|                             | }                                |
+-----------------------------+----------------------------------+
| Recommended sampling params | {                                |
|                             |     "strategy": {                |
|                             |         "type": "top_p",         |
|                             |         "temperature": 1.0,      |
|                             |         "top_p": 0.9             |
|                             |     }                            |
|                             | }                                |
+-----------------------------+----------------------------------+
```