### PR TITLE
[Test Automation] Add schedule job as accepted job for PRs and cron jobs

### DIFF
--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -235,9 +235,9 @@ jobs:
 
       #### Create test summary ####
 
-      - name: "Manual - Test Summary"
+      - name: "Test Summary"
         id: manual_test_summary
-        if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
+        if: if:always()
         uses: test-summary/action@v2
         with:
           paths: "${{ github.workspace }}/result.xml"

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -69,7 +69,7 @@ jobs:
     defaults:
       run:
         shell: bash # default shell to run all steps for a given job.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || 'llama-models-fork-gha-runner-cpu' }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || 'llama-models-gha-runner-cpu' }}
     if: always()
     steps:
 

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   execute_workflow:
-    name: Execute workload on Self-Hosted CPU k8s runner
+    name: Execute workload on Self-Hosted GPU/CPU k8s runner
     permissions:
       pull-requests: write
     defaults:
@@ -230,14 +230,19 @@ jobs:
         if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
         run: |
           echo "[STEP] Running PyTest tests at 'GITHUB_WORKSPACE' path: ${GITHUB_WORKSPACE} | path: ${{ github.workspace }}"
-          free -m
-          python3 -m pytest --junitxml="${{ github.workspace }}/result.xml"
+          if [[ "${{ inputs.runner }}" == *"-cpu"* ]]; then
+            python3 -m pytest --ignore=models/llama3/tests/api/test_generation.py --ignore=llama_models/llama3/tests/api/test_generation.py --junitxml="${{ github.workspace }}/result.xml"
+          elif [[ "${{ inputs.runner }}" == *"-gpu"* ]]; then
+            python3 -m pytest --junitxml="${{ github.workspace }}/result.xml"
+          else
+            exit 1
+          fi
 
       #### Create test summary ####
 
       - name: "Test Summary"
         id: manual_test_summary
-        if: if:always()
+        if: always()
         uses: test-summary/action@v2
         with:
           paths: "${{ github.workspace }}/result.xml"

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -69,7 +69,7 @@ jobs:
     defaults:
       run:
         shell: bash # default shell to run all steps for a given job.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || 'llama-models-gha-runner-cpu' }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || github.repository_owner == 'meta-llama' && 'llama-models-gha-runner-cpu' || 'llama-models-fork-gha-runner-cpu' }}
     if: always()
     steps:
 

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -69,7 +69,7 @@ jobs:
     defaults:
       run:
         shell: bash # default shell to run all steps for a given job.
-    runs-on: ${{ inputs.runner != '' && inputs.runner || 'llama-models-gha-runner-cpu' }}
+    runs-on: ${{ inputs.runner != '' && inputs.runner || 'llama-models-fork-gha-runner-cpu' }}
     if: always()
     steps:
 

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -238,6 +238,10 @@ jobs:
             exit 1
           fi
 
+      #####################
+      #### ALL TESTING ####
+      #####################
+
       #### Create test summary ####
 
       - name: "Test Summary"

--- a/.github/workflows/gha_workflow_llama_models_tests.yml
+++ b/.github/workflows/gha_workflow_llama_models_tests.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: "Installing specific manual_dispatch dependencies"
         id: manual_install_pip
-        if: github.event_name == 'workflow_dispatch'
+        if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
         run: |
           echo "[STEP] Installing specific dependencies for manual dispatch workflows"
           pip install numpy
@@ -227,7 +227,7 @@ jobs:
       - name: "Manual - Run Tests"
         id: manual_run_tests
         working-directory: "${{ github.workspace }}"
-        if: github.event_name == 'workflow_dispatch'
+        if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
         run: |
           echo "[STEP] Running PyTest tests at 'GITHUB_WORKSPACE' path: ${GITHUB_WORKSPACE} | path: ${{ github.workspace }}"
           free -m
@@ -237,7 +237,7 @@ jobs:
 
       - name: "Manual - Test Summary"
         id: manual_test_summary
-        if: always() && github.event_name == 'workflow_dispatch'
+        if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
         uses: test-summary/action@v2
         with:
           paths: "${{ github.workspace }}/result.xml"

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # top-level folder for each specific model found within the models/ directory at
 # the top-level of this source tree.
+# This is a test PR submission.
 
 import os
 import unittest

--- a/models/llama3/tests/api/test_generation.py
+++ b/models/llama3/tests/api/test_generation.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # top-level folder for each specific model found within the models/ directory at
 # the top-level of this source tree.
-# This is a test PR submission.
 
 import os
 import unittest


### PR DESCRIPTION
# What does this PR do?

Updates CI/CD testing to the schedule workflow job for PRs, manual dispatch, and cron jobs.

- PRs previously would not update the Workflow summary page with the test summary.  They would only update the test summary on the PR itself as a comment.  This fixes it so the test-summary is displayed as a PR comment **AND** GHA summary.
- Cron jobs were scheduled, but did not include any tests.  This fixes that.
- Manual dispatch step variants have been updated to include 'schedule' jobs.

## Test Plan
- [Manual Dispatch Run (GPU)](https://github.com/ConnorHack/llama-models/actions/runs/12993349792)
- [PR Test Run (CPU)](https://github.com/ConnorHack/llama-models/pull/23)