### PR TITLE
chore(precommit): add uv-sync hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     hooks:
     -   id: uv-export
         args: ["--frozen", "--no-hashes", "--no-emit-project"]
+    -   id: uv-sync
 
 # -   repo: https://github.com/pre-commit/mirrors-mypy
 #     rev: v1.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: 0.5.26
     hooks:
     -   id: uv-export
-        args: ["--frozen", "--no-hashes", "--no-emit-project"]
+        args: ["--frozen", "--no-hashes", "--no-emit-project", "--output-file=requirements.txt"]
     -   id: uv-sync
 
 # -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ Meta has a [bounty program](http://facebook.com/whitehat/info) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
-## Coding Style  
+## Coding Style
 * 2 spaces for indentation rather than tabs
-* 80 character line length
+* 120 character line length
 * ...
 
 ## License

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -241,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "llama-models"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -283,6 +284,7 @@ requires-dist = [
     { name = "tiktoken" },
     { name = "torch", marker = "extra == 'torch'" },
 ]
+provides-extras = ["dev", "torch"]
 
 [[package]]
 name = "lxml"


### PR DESCRIPTION
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>

When standing up a dev setup, I've discovered a mismatch between `pyproject.toml` and `uv.lock` - call to `uv sync --extra dev` results in diff on `uv.lock`.

It seems like during the [last version bump](https://github.com/meta-llama/llama-models/commit/c5f59584982e6f1c5ce2dd5a9d2a5763891ec276), the `uv.lock` was not regenerated. This discrepancy can be mitigated by adding a `uv-sync` hook to the precommit (fcf889359a49dd221d025a01c71b348e77089ead). The same hook is already present in the [`llama-stack` repo ](https://github.com/meta-llama/llama-stack/blob/d954f2752e386634f861e0447e9998e0ab15d15c/.pre-commit-config.yaml#L51) so I guess it would be worth adding it here as well.

After adding the hook, I've just ran `precommit run -a` and discovered some discrepancies here and there, so I've fixed those in this PR as well (let me know if I should move them to a separate PR).

This repo is also missing a precommit CI workflow, should I add that as well? Or would you prefer a separate PR?