### PR TITLE
fix: tool_call was not encoded

### DIFF
--- a/models/llama3/api/chat_format.py
+++ b/models/llama3/api/chat_format.py
@@ -149,8 +149,9 @@ class ChatFormat:
     def encode_dialog_prompt(
         self,
         messages: List[RawMessage],
-        tool_prompt_format: ToolPromptFormat = ToolPromptFormat.json,
+        tool_prompt_format: Optional[ToolPromptFormat] = None,
     ) -> LLMInput:
+        tool_prompt_format = tool_prompt_format or ToolPromptFormat.json
         tokens = []
         images = []
         tokens.append(self.tokenizer.special_tokens["<|begin_of_text|>"])

--- a/models/llama3/api/tool_utils.py
+++ b/models/llama3/api/tool_utils.py
@@ -190,3 +190,5 @@ class ToolUtils:
 
                 args_str = ", ".join(f"{k}={format_value(v)}" for k, v in t.arguments.items())
                 return f"[{fname}({args_str})]"
+            else:
+                raise ValueError(f"Unsupported tool prompt format: {tool_prompt_format}")


### PR DESCRIPTION
Summary:
Our default tool_prompt_format is None and https://github.com/meta-llama/llama-stack/pull/1198 passed that in.


Test Plan:

Previously failing test LLAMA_STACK_CONFIG=fireworks pytest -s -v tests/client-sdk/agents/test_agents.py::test_create_turn_response --safety-shield meta-llama/Llama-Guard-3-8B
