### PR TITLE
Add webpage integration instructions to model cards

### DIFF
--- a/models/llama3_1/MODEL_CARD.md
+++ b/models/llama3_1/MODEL_CARD.md
@@ -975,3 +975,33 @@ Finally, we put in place a set of resources including an [output reporting mecha
 The core values of Llama 3.1 are openness, inclusivity and helpfulness. It is meant to serve everyone, and to work for a wide range of use cases. It is thus designed to be accessible to people across many different backgrounds, experiences and perspectives. Llama 3.1 addresses users and their needs as they are, without insertion unnecessary judgment or normativity, while reflecting the understanding that even content that may appear problematic in some cases can serve valuable purposes in others. It respects the dignity and autonomy of all users, especially in terms of the values of free thought and expression that power innovation and progress.
 
 But Llama 3.1 is a new technology, and like any new technology, there are risks associated with its use. Testing conducted to date has not covered, nor could it cover, all scenarios. For these reasons, as with all LLMs, Llama 3.1’s potential outputs cannot be predicted in advance, and the model may in some instances produce inaccurate, biased or other objectionable responses to user prompts. Therefore, before deploying any applications of Llama 3.1 models, developers should perform safety testing and tuning tailored to their specific applications of the model. Please refer to available resources including our [Responsible Use Guide](https://llama.meta.com/responsible-use-guide), [Trust and Safety](https://llama.meta.com/trust-and-safety/) solutions, and other [resources](https://llama.meta.com/docs/get-started/) to learn more about responsible development.
+
+## Webpage Integration
+
+The purpose of the new sophisticated webpage is to provide users with an enhanced and interactive experience when using the Llama 3.1 model. This webpage will allow users to easily interact with the model, visualize outputs, and access additional resources and documentation.
+
+### Integration Instructions
+
+1. **Setup the Webpage**:
+   - Clone the repository containing the webpage code.
+   - Install the necessary dependencies using `npm install`.
+   - Start the development server using `npm start`.
+
+2. **Connect to the Llama 3.1 Model**:
+   - Ensure the Llama 3.1 model is running and accessible via an API endpoint.
+   - Update the webpage configuration to point to the Llama 3.1 model's API endpoint.
+
+3. **Customize the Interface**:
+   - Modify the webpage's user interface to suit your needs. This may include changing the layout, colors, and adding custom features.
+   - Use the provided components and templates to quickly build and customize the interface.
+
+4. **Deploy the Webpage**:
+   - Once you are satisfied with the customization, build the production version of the webpage using `npm run build`.
+   - Deploy the built files to your preferred hosting service.
+
+5. **Access and Use**:
+   - Open the deployed webpage in a web browser.
+   - Interact with the Llama 3.1 model through the webpage interface.
+   - Utilize the various features and tools provided to enhance your experience with the model.
+
+By following these instructions, you can successfully integrate the new sophisticated webpage with the Llama 3.1 model and provide users with an improved and interactive experience.

--- a/models/llama3_2/MODEL_CARD.md
+++ b/models/llama3_2/MODEL_CARD.md
@@ -214,3 +214,33 @@ Our attack automation study focused on evaluating the capabilities of LLMs when 
 **Values:** The core values of Llama 3.2 are openness, inclusivity and helpfulness. It is meant to serve everyone, and to work for a wide range of use cases. It is thus designed to be accessible to people across many different backgrounds, experiences and perspectives. Llama 3.2 addresses users and their needs as they are, without insertion unnecessary judgment or normativity, while reflecting the understanding that even content that may appear problematic in some cases can serve valuable purposes in others. It respects the dignity and autonomy of all users, especially in terms of the values of free thought and expression that power innovation and progress.
 
 **Testing:** Llama 3.2 is a new technology, and like any new technology, there are risks associated with its use. Testing conducted to date has not covered, nor could it cover, all scenarios. For these reasons, as with all LLMs, Llama 3.2’s potential outputs cannot be predicted in advance, and the model may in some instances produce inaccurate, biased or other objectionable responses to user prompts. Therefore, before deploying any applications of Llama 3.2 models, developers should perform safety testing and tuning tailored to their specific applications of the model. Please refer to available resources including our [Responsible Use Guide](https://llama.meta.com/responsible-use-guide), [Trust and Safety](https://llama.meta.com/trust-and-safety/) solutions, and other [resources](https://llama.meta.com/docs/get-started/) to learn more about responsible development.
+
+## Webpage Integration
+
+The purpose of the new sophisticated webpage is to provide users with an enhanced and interactive experience when using the Llama 3.2 model. This webpage will allow users to easily interact with the model, visualize outputs, and access additional resources and documentation.
+
+### Integration Instructions
+
+1. **Setup the Webpage**:
+   - Clone the repository containing the webpage code.
+   - Install the necessary dependencies using `npm install`.
+   - Start the development server using `npm start`.
+
+2. **Connect to the Llama 3.2 Model**:
+   - Ensure the Llama 3.2 model is running and accessible via an API endpoint.
+   - Update the webpage configuration to point to the Llama 3.2 model's API endpoint.
+
+3. **Customize the Interface**:
+   - Modify the webpage's user interface to suit your needs. This may include changing the layout, colors, and adding custom features.
+   - Use the provided components and templates to quickly build and customize the interface.
+
+4. **Deploy the Webpage**:
+   - Once you are satisfied with the customization, build the production version of the webpage using `npm run build`.
+   - Deploy the built files to your preferred hosting service.
+
+5. **Access and Use**:
+   - Open the deployed webpage in a web browser.
+   - Interact with the Llama 3.2 model through the webpage interface.
+   - Utilize the various features and tools provided to enhance your experience with the model.
+
+By following these instructions, you can successfully integrate the new sophisticated webpage with the Llama 3.2 model and provide users with an improved and interactive experience.

--- a/models/llama3_2/MODEL_CARD_VISION.md
+++ b/models/llama3_2/MODEL_CARD_VISION.md
@@ -158,3 +158,33 @@ Our attack automation study focused on evaluating the capabilities of LLMs when 
 **Values:** The core values of Llama 3.2 are openness, inclusivity and helpfulness. It is meant to serve everyone, and to work for a wide range of use cases. It is thus designed to be accessible to people across many different backgrounds, experiences and perspectives. Llama 3.2 addresses users and their needs as they are, without insertion unnecessary judgment or normativity, while reflecting the understanding that even content that may appear problematic in some cases can serve valuable purposes in others. It respects the dignity and autonomy of all users, especially in terms of the values of free thought and expression that power innovation and progress.
 
 **Testing:** But Llama 3.2 is a new technology, and like any new technology, there are risks associated with its use. Testing conducted to date has not covered, nor could it cover, all scenarios. For these reasons, as with all LLMs, Llama 3.2’s potential outputs cannot be predicted in advance, and the model may in some instances produce inaccurate, biased or other objectionable responses to user prompts. Therefore, before deploying any applications of Llama 3.2 models, developers should perform safety testing and tuning tailored to their specific applications of the model. Please refer to available resources including our [Responsible Use Guide](https://llama.meta.com/responsible-use-guide), [Trust and Safety](https://llama.meta.com/trust-and-safety/) solutions, and other [resources](https://llama.meta.com/docs/get-started/) to learn more about responsible development.
+
+## Webpage Integration
+
+The purpose of the new sophisticated webpage is to provide users with an enhanced and interactive experience when using the Llama 3.2-Vision model. This webpage will allow users to easily interact with the model, visualize outputs, and access additional resources and documentation.
+
+### Integration Instructions
+
+1. **Setup the Webpage**:
+   - Clone the repository containing the webpage code.
+   - Install the necessary dependencies using `npm install`.
+   - Start the development server using `npm start`.
+
+2. **Connect to the Llama 3.2-Vision Model**:
+   - Ensure the Llama 3.2-Vision model is running and accessible via an API endpoint.
+   - Update the webpage configuration to point to the Llama 3.2-Vision model's API endpoint.
+
+3. **Customize the Interface**:
+   - Modify the webpage's user interface to suit your needs. This may include changing the layout, colors, and adding custom features.
+   - Use the provided components and templates to quickly build and customize the interface.
+
+4. **Deploy the Webpage**:
+   - Once you are satisfied with the customization, build the production version of the webpage using `npm run build`.
+   - Deploy the built files to your preferred hosting service.
+
+5. **Access and Use**:
+   - Open the deployed webpage in a web browser.
+   - Interact with the Llama 3.2-Vision model through the webpage interface.
+   - Utilize the various features and tools provided to enhance your experience with the model.
+
+By following these instructions, you can successfully integrate the new sophisticated webpage with the Llama 3.2-Vision model and provide users with an improved and interactive experience.


### PR DESCRIPTION
Add a new section titled "Webpage Integration" to the model card files for Llama 3.1, Llama 3.2, and Llama 3.2-Vision.

* **Llama 3.1 Model Card**:
  - Add a section titled "Webpage Integration" at the end of the file.
  - Describe the purpose of the new sophisticated webpage.
  - Provide detailed instructions on how to integrate the webpage with the Llama 3.1 model.

* **Llama 3.2-Vision Model Card**:
  - Add a section titled "Webpage Integration" at the end of the file.
  - Describe the purpose of the new sophisticated webpage.
  - Provide detailed instructions on how to integrate the webpage with the Llama 3.2-Vision model.

* **Llama 3.2 Model Card**:
  - Add a section titled "Webpage Integration" at the end of the file.
  - Describe the purpose of the new sophisticated webpage.
  - Provide detailed instructions on how to integrate the webpage with the Llama 3.2 model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/meta-llama/llama-models?shareId=XXXX-XXXX-XXXX-XXXX).