### PR TITLE
Improve readability of PixelShuffle operation in Llama4

### DIFF
--- a/models/llama4/vision/embedding.py
+++ b/models/llama4/vision/embedding.py
@@ -18,11 +18,11 @@ from .encoder import VisionEncoder
 
 
 class PixelShuffle(nn.Module):
-    def __init__(self, ps_ratio):
+    def __init__(self, ps_ratio: float):
         super().__init__()
         self.ps_ratio = ps_ratio
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         # x: [B, N, C], N = number of patches
         assert self.ps_ratio is not None, "ps_ratio is required for pixel shuffle"
         assert x.dim() == 3, "pixel shuffle requires encoded patches [B, N, C]"
@@ -33,14 +33,14 @@ class PixelShuffle(nn.Module):
         return pixel_shuffle_patches
 
 
-def pixel_shuffle_op(input_x, ps_ratio):
-    n, w, h, c = input_x.size()
-    input_x = input_x.view(n, w, int(h * ps_ratio), int(c / ps_ratio))
+def pixel_shuffle_op(input_x: torch.Tensor, ps_ratio: float) -> torch.Tensor:
+    n, h, w, c = input_x.size()
+    input_x = input_x.view(n, h, int(w * ps_ratio), int(c / ps_ratio))
     input_x = input_x.permute(0, 2, 1, 3).contiguous()
     input_x = input_x.view(
         n,
-        int(h * ps_ratio),
         int(w * ps_ratio),
+        int(h * ps_ratio),
         int(c / (ps_ratio * ps_ratio)),
     )
     input_x = input_x.permute(0, 2, 1, 3).contiguous()


### PR DESCRIPTION
This PR improves the readability of the `pixel_shuffle_op()` function within [llama_models/llama4/vision/embedding.py](https://github.com/meta-llama/llama-models/blob/2b2e5b2645c962f92dc004aa868696ec0e53b05c/models/llama4/vision/embedding.py).

Previously, the input tensor dimensions were unpacked as `n, w, h, c = input_x.size()`, but since the tensor dimensions within `PixelShuffle.forward()` are expected to be $[N, H, W, C]$, this PR aligns the naming accordingly.

Since the implementation assumes a square patch input, this change does not affect the underlying logic and is strictly for readability enhancement.

Additionally, the type annotation for ps_ratio has been added because it differs slightly from [`torch.nn.PixelShuffle`](https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html) by accepting a `float`.