### PR TITLE
fix: Runtime Error when quantizing Llama 4 Scout to INT4

### DIFF
--- a/models/llama4/quantization/loader.py
+++ b/models/llama4/quantization/loader.py
@@ -92,7 +92,7 @@ def convert_to_quantized_model(
             log_status(f"Rank {rank}: Quantizing int4 weights from bf16")
 
             def apply_quantization(_, weight):
-                return quantize_int4(weight, fp8_activation_scale_ub, output_device=torch.device("cuda"))
+                return quantize_int4(weight, output_device=torch.device("cuda"))
 
     else:
         fp8_scales_path = os.path.join(checkpoint_dir, f"fp8_scales_{rank}.pt")


### PR DESCRIPTION
When I try to run the int4 quantization of llama 4 Scout on the main branch using the script below according to the README, the following error occurs.

```sh
MODE=int4_mixed  # or int4_mixed
if [ $MODE == "fp8_mixed" ]; then
  NGPUS=2
else
  NGPUS=1
fi
CHECKPOINT_DIR=~/.llama/checkpoints/Llama-4-Scout-17B-16E-Instruct
PYTHONPATH=$(git rev-parse --show-toplevel) \
  torchrun --nproc_per_node=$NGPUS \
  -m models.llama4.scripts.chat_completion $CHECKPOINT_DIR \
  --world_size $NGPUS \
  --quantization-mode $MODE
```

```
Resharding 8 state dicts from MP size 8 to MP size 1
Loaded checkpoint
Loading state dict...
Done...
Rank 0: Quantizing int4 weights from bf16
⠙   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━                            0%     0:00:00      ETA:    -:--:--      Rank 0 - Layer 0 - MoE w1              
[rank0]: Traceback (most recent call last):
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "./llama-models/models/llama4/scripts/chat_completion.py", line 114, in <module>
[rank0]:     main()
[rank0]:   File "./llama-models/models/llama4/scripts/chat_completion.py", line 110, in main
[rank0]:     fire.Fire(run_main)
[rank0]:   File "./.venv/lib/python3.11/site-packages/fire/core.py", line 135, in Fire
[rank0]:     component_trace = _Fire(component, args, parsed_flag_args, context, name)
[rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "./.venv/lib/python3.11/site-packages/fire/core.py", line 468, in _Fire
[rank0]:     component, remaining_args = _CallAndUpdateTrace(
[rank0]:                                 ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "./.venv/lib/python3.11/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
[rank0]:     component = fn(*varargs, **kwargs)
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "./llama-models/models/llama4/scripts/chat_completion.py", line 33, in run_main
[rank0]:     generator = Llama4.build(
[rank0]:                 ^^^^^^^^^^^^^
[rank0]:   File "./llama-models/models/llama4/generation.py", line 97, in build
[rank0]:     model = convert_to_quantized_model(model, ckpt_dir, quantization_mode)
[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "./llama-models/models/llama4/quantization/loader.py", line 140, in convert_to_quantized_model
[rank0]:     apply_quantization(
[rank0]:   File "./llama-models/models/llama4/quantization/loader.py", line 95, in apply_quantization
[rank0]:     return quantize_int4(weight, fp8_activation_scale_ub, output_device=torch.device("cuda"))
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "./.venv/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: quantize_int4() got multiple values for argument 'output_device'
```

This is probably due to the difference in function definition between fp8 and int4. In fact, when I fix it according to this PR, it works fine (and the model response will also appear to be correct).