### PR TITLE
feat: add xpu support to llama3 completion scripts

### DIFF
--- a/models/llama3/scripts/chat_completion.py
+++ b/models/llama3/scripts/chat_completion.py
@@ -18,7 +18,20 @@ from termcolor import cprint
 from models.datatypes import RawMediaItem, RawMessage, RawTextItem, StopReason
 from models.llama3.generation import Llama3
 
+import os
+import torch
+
 THIS_DIR = Path(__file__).parent
+
+
+def get_device():
+    if "DEVICE" in os.environ:
+        return os.environ["DEVICE"]
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
 
 
 def run_main(
@@ -36,6 +49,7 @@ def run_main(
         max_batch_size=max_batch_size,
         world_size=world_size,
         quantization_mode=quantization_mode,
+        device=get_device(),
     )
 
     dialogs = [

--- a/models/llama3/scripts/completion.py
+++ b/models/llama3/scripts/completion.py
@@ -18,7 +18,21 @@ from termcolor import cprint
 from models.datatypes import RawMediaItem
 from models.llama3.generation import Llama3
 
+import os
+import torch
+
+
 THIS_DIR = Path(__file__).parent
+
+
+def get_device():
+    if "DEVICE" in os.environ:
+        return os.environ["DEVICE"]
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
 
 
 def run_main(
@@ -36,6 +50,7 @@ def run_main(
         max_batch_size=max_batch_size,
         world_size=world_size,
         quantization_mode=quantization_mode,
+        device=get_device(),
     )
 
     interleaved_contents = [


### PR DESCRIPTION
Verified with `Llama3.2-3B-Instruct` on Intel Data Center Max Series GPU (PVC):
```
torchrun --nproc-per-node=1 models/llama3/scripts/completion.py \
 "$CHECKPOINT_DIR" --world_size 1

torchrun --nproc-per-node=1 models/llama3/scripts/chat_completion.py \
 "$CHECKPOINT_DIR" --world_size 1
```

CC: @ashwinb, @raghotham