### PR TITLE
fix: on-the-fly int4 quantize parameter

### DIFF
--- a/models/llama4/quantization/loader.py
+++ b/models/llama4/quantization/loader.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional
 
 import torch
 from fairscale.nn.model_parallel.initialize import get_model_parallel_rank
-from torch import Tensor, nn
+from torch import nn, Tensor
 from torch.nn import functional as F
 
 from ...datatypes import QuantizationMode
@@ -92,7 +92,7 @@ def convert_to_quantized_model(
             log_status(f"Rank {rank}: Quantizing int4 weights from bf16")
 
             def apply_quantization(_, weight):
-                return quantize_int4(weight, fp8_activation_scale_ub, output_device=torch.device("cuda"))
+                return quantize_int4(weight, output_device=torch.device("cuda"))
 
     else:
         fp8_scales_path = os.path.join(checkpoint_dir, f"fp8_scales_{rank}.pt")


### PR DESCRIPTION
```
PYTHONPATH=$(git rev-parse --show-toplevel) \
torchrun --nproc_per_node=1 \
-m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct \
--world_size 1 \
--quantization-mode int4_mixed
```

Before this PR:
```
[rank1]: TypeError: quantize_int4() got multiple values for argument 'output_device'
```