### PR TITLE
feat: support cpu and xpu devices in llama4

### DIFF
--- a/models/llama4/model.py
+++ b/models/llama4/model.py
@@ -161,7 +161,7 @@ class Attention(nn.Module):
                 self.n_local_kv_heads,
                 self.head_dim,
             )
-        ).cuda()
+        )
         self.cache_v = torch.zeros(
             (
                 args.max_batch_size,
@@ -169,7 +169,7 @@ class Attention(nn.Module):
                 self.n_local_kv_heads,
                 self.head_dim,
             )
-        ).cuda()
+        )
         self.norm_eps = args.norm_eps
         self._register_load_state_dict_pre_hook(self.load_hook)
 

--- a/models/llama4/scripts/chat_completion.py
+++ b/models/llama4/scripts/chat_completion.py
@@ -18,7 +18,20 @@ from termcolor import cprint
 from models.datatypes import RawMediaItem, RawMessage, RawTextItem, StopReason
 from models.llama4.generation import Llama4
 
+import os
+import torch
+
 THIS_DIR = Path(__file__).parent
+
+
+def get_device():
+    if "DEVICE" in os.environ:
+        return os.environ["DEVICE"]
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
 
 
 def run_main(
@@ -36,6 +49,7 @@ def run_main(
         max_batch_size=max_batch_size,
         world_size=world_size,
         quantization_mode=quantization_mode,
+        device=get_device(),
     )
 
     dialogs = [

--- a/models/llama4/scripts/completion.py
+++ b/models/llama4/scripts/completion.py
@@ -18,7 +18,20 @@ from termcolor import cprint
 from models.datatypes import RawMediaItem
 from models.llama4.generation import Llama4
 
+import os
+import torch
+
 THIS_DIR = Path(__file__).parent
+
+
+def get_device():
+    if "DEVICE" in os.environ:
+        return os.environ["DEVICE"]
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
 
 
 def run_main(
@@ -36,6 +49,7 @@ def run_main(
         max_batch_size=max_batch_size,
         world_size=world_size,
         quantization_mode=quantization_mode,
+        device=get_device(),
     )
 
     with open(THIS_DIR / "../../resources/dog.jpg", "rb") as f:


### PR DESCRIPTION
Chang is similar to the one previously done for Llama3.

CPU support tried on Intel Xeon.

XPU support tried on Intel Data Center GPU Max series. Note that a fix in fairscale for https://github.com/facebookresearch/fairscale/issues/1195 is required to make XPU working (CPU not affected). I believe that this fix might also be needed for CUDA as well since issue seems to be device agnostic and I see it with the simplified reproducer on NVidia A10.

Verified on the platforms named above with LLama4 sample completion and chat completion scripts.

Requires: https://github.com/facebookresearch/fairscale/pull/1196
CC: @ashwinb, @raghotham