### PR TITLE
fix: re-add python_start, python_end tokens

### DIFF
--- a/models/llama4/tokenizer.py
+++ b/models/llama4/tokenizer.py
@@ -57,8 +57,8 @@ LLAMA4_TEXT_POST_TRAIN_SPECIAL_TOKENS = [
     "<|text_post_train_reserved_special_token_3|>",
     "<|text_post_train_reserved_special_token_4|>",
     "<|text_post_train_reserved_special_token_5|>",
-    "<|text_post_train_reserved_special_token_6|>",
-    "<|text_post_train_reserved_special_token_7|>",
+    "<|python_start|>",
+    "<|python_end|>",
     "<|finetune_right_pad|>",
 ] + get_reserved_special_tokens(
     "text_post_train", 61, 8


### PR DESCRIPTION
The Scout model produces these tokens, there is no point hiding them.

Will also mirror this change in llama-stack.

## Test Plan

Add the following dialog and run chat_completion.py
```
  [
    RawMessage(role="system", content="Environment: ipython\nTools: brave_search, wolfram_alpha\n\n"),
    RawMessage(role="user", content="What is square root of pi?"),
  ],
```

See: 
<img width="526" alt="image" src="https://github.com/user-attachments/assets/d0a4407c-6b64-414e-958e-3346ff202e8a" />
