### PR TITLE
Enable loading pre-quantized INT4 weights in Llama4

### DIFF
--- a/models/llama4/args.py
+++ b/models/llama4/args.py
@@ -19,6 +19,7 @@ class QuantizationArgs(BaseModel):
     scheme: Optional[QuantizationScheme] = None
     group_size: Optional[int] = None
     spinquant: bool = False
+    int4_weight: bool = False
 
 
 class LoRAArgs(BaseModel):

--- a/models/llama4/model.py
+++ b/models/llama4/model.py
@@ -16,6 +16,7 @@ from fairscale.nn.model_parallel.layers import (
     RowParallelLinear,
     VocabParallelEmbedding,
 )
+from models.quantize_impls import load_int4
 from torch import nn
 
 from .args import ModelArgs
@@ -269,6 +270,7 @@ class TransformerBlock(nn.Module):
                 ffn_dim_multiplier=args.ffn_dim_multiplier,
                 multiple_of=args.multiple_of,
                 moe_args=args.moe_args,
+                int4_weight=(args.quantization_args.int4_weight if args.quantization_args is not None else False),
             )
         else:
             hidden_dim = int(4 * args.dim)
@@ -280,6 +282,7 @@ class TransformerBlock(nn.Module):
             self.feed_forward = FeedForward(
                 dim=args.dim,
                 hidden_dim=hidden_dim,
+                int4_weight=(args.quantization_args.int4_weight if args.quantization_args is not None else False),
             )
         self.layer_id = layer_id
         self.attention_norm = RMSNorm(args.dim, eps=args.norm_eps)

--- a/models/llama4/scripts/quantize.py
+++ b/models/llama4/scripts/quantize.py
@@ -18,6 +18,7 @@ from models.llama4.args import ModelArgs
 from models.llama4.generation import QuantizationMode
 from models.llama4.model import MoE, Transformer, TransformerBlock
 from models.quantize_impls import int4_row_quantize, pack_int4
+from torch import nn
 
 try:
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401
@@ -66,7 +67,9 @@ def ffn_quantize(
         output_dir (str): The directory to save the quantized checkpoint and fp8/int4 scales.
         world_size (Optional[int]): The number of GPUs to use for model parallelization.
     """
-    print(f"checkpoint_dir: {ckpt_dir} output_dir: {output_dir} world_size: {world_size}")
+    print(
+        f"checkpoint_dir: {ckpt_dir} output_dir: {output_dir} world_size: {world_size}"
+    )
     if not torch.distributed.is_initialized():
         torch.distributed.init_process_group("nccl")
 
@@ -88,9 +91,9 @@ def ffn_quantize(
 
     checkpoints = set(Path(ckpt_dir).glob("*.pth"))
     assert len(checkpoints) > 0, f"no checkpoint files found in {ckpt_dir}"
-    assert world_size == len(checkpoints), (
-        f"Loading a checkpoint for MP={len(checkpoints)} but world size is {world_size}"
-    )
+    assert world_size == len(
+        checkpoints
+    ), f"Loading a checkpoint for MP={len(checkpoints)} but world size is {world_size}"
     checkpoints = sorted(checkpoints)
     ckpt_idx = get_model_parallel_rank()
     ckpt_path = checkpoints[ckpt_idx]
@@ -112,16 +115,26 @@ def ffn_quantize(
     model.load_state_dict(checkpoint, strict=False)
     print("Done...")
 
+    def should_quantize_block(block: nn.Module) -> bool:
+        if not isinstance(block, TransformerBlock):
+            return False
+
+        is_moe = isinstance(block.feed_forward, MoE)
+        if quantization_mode == QuantizationMode.fp8_mixed:
+            # skip quantization on first and last layers
+            return is_moe and not (
+                block.layer_id == 0 or block.layer_id == (model.n_layers - 1)
+            )
+
+        return is_moe
+
     fp8_scales = {}
     int4_scales = {}
     old_keys = set(checkpoint.keys())
     new_state_dict = checkpoint
     for _, block in model.named_modules():
         if isinstance(block, TransformerBlock):
-            if block.layer_id == 0 or block.layer_id == (model.n_layers - 1):
-                continue
-
-            if not isinstance(block.feed_forward, MoE):
+            if not should_quantize_block(block):
                 continue
 
             # IMPORTANT NOTE:
@@ -147,12 +160,12 @@ def ffn_quantize(
                     weight = param.transpose(1, 2).contiguous()
 
                     if weight.ndim >= 3:
-                        wq, scale = zip(*[int4_row_quantize(i.cuda()) for i in weight])
-                        wq = torch.stack([pack_int4(i.cuda()) for i in wq], dim=0)
+                        wq, scale = zip(*[int4_row_quantize(i) for i in weight])
+                        wq = torch.stack([pack_int4(i) for i in wq], dim=0)
                         w_scale = torch.stack(scale, dim=0)
                     else:
-                        wq, w_scale = int4_row_quantize(weight.cuda())
-                        wq = pack_int4(wq.cuda())
+                        wq, w_scale = int4_row_quantize(weight)
+                        wq = pack_int4(wq)
 
                     state_dict_key_map = {
                         "w1": "moe_w_in_eD_F",
@@ -164,17 +177,42 @@ def ffn_quantize(
                     wq = wq.transpose(1, 2).reshape(*new_shape).contiguous()
 
                     # torch.nn.Parameter requires weights be floating point, so we cast packed int8 (2 * int4) to float8_e4m3fn, and will cast back to int8 in loading code
-                    new_state_dict[f"{prefix}.experts.{state_dict_key_map[key]}"] = torch.nn.Parameter(
-                        wq.view(torch.float8_e4m3fn)
+                    new_state_dict[f"{prefix}.experts.{state_dict_key_map[key]}"] = (
+                        torch.nn.Parameter(wq.view(torch.float8_e4m3fn))
                     )
-                    int4_scales[f"{prefix}.experts.{key}"] = w_scale
-                    print(f"Quantized {prefix}.experts.{state_dict_key_map[key]} {wq.shape=} {w_scale.shape=}")
+                    int4_scales[f"{prefix}.experts.{state_dict_key_map[key]}"] = w_scale
+                    print(
+                        f"Quantized {prefix}.experts.{key} {wq.shape=} {w_scale.shape=}"
+                    )
+
+                    param = getattr(moe.shared_expert, key)
+                    weight = param.weight
+                    if weight.ndim >= 3:
+                        wq, scale = zip(*[int4_row_quantize(i) for i in weight])
+                        wq = torch.stack([pack_int4(i) for i in wq], dim=0)
+                        w_scale = torch.stack(scale, dim=0)
+                    else:
+                        wq, w_scale = int4_row_quantize(weight)
+                        wq = pack_int4(wq)
+
+                    state_dict_key_map = {
+                        "w1": "w_in_shared_FD.weight",
+                        "w2": "w_out_shared_DF.weight",
+                        "w3": "w_swiglu_FD.weight",
+                    }
+                    new_state_dict[f"{prefix}.{state_dict_key_map[key]}"] = (
+                        torch.nn.Parameter(wq.view(torch.float8_e4m3fn))
+                    )
+                    int4_scales[f"{prefix}.{state_dict_key_map[key]}"] = w_scale
+                    print(f"Quantized {prefix}.{key} {wq.shape=} {w_scale.shape=}")
 
             else:
                 for key in ("w1", "w3", "w2"):
                     param = getattr(moe.experts, key)
                     shape = param.shape
-                    wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_row(param.transpose(1, 2).contiguous())
+                    wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_row(
+                        param.transpose(1, 2).contiguous()
+                    )
 
                     state_dict_key_map = {
                         "w1": "moe_w_in_eD_F",
@@ -185,9 +223,13 @@ def ffn_quantize(
                     new_shape = (-1, shape[-1])
                     wq = wq.transpose(1, 2).reshape(*new_shape).contiguous()
 
-                    new_state_dict[f"{prefix}.experts.{state_dict_key_map[key]}"] = torch.nn.Parameter(wq)
-                    fp8_scales[f"{prefix}.experts.{key}"] = w_scale
-                    print(f"Quantized {prefix}.experts.{state_dict_key_map[key]} {wq.shape=} {w_scale.shape=}")
+                    new_state_dict[f"{prefix}.experts.{state_dict_key_map[key]}"] = (
+                        torch.nn.Parameter(wq)
+                    )
+                    fp8_scales[f"{prefix}.experts.{state_dict_key_map[key]}"] = w_scale
+                    print(
+                        f"Quantized {prefix}.experts.{state_dict_key_map[key]} {wq.shape=} {w_scale.shape=}"
+                    )
 
     new_keys = set(new_state_dict.keys())
     assert old_keys == new_keys, f"old_keys != new_keys: {old_keys - new_keys}"

--- a/models/quantize_impls.py
+++ b/models/quantize_impls.py
@@ -250,7 +250,7 @@ def load_int4(
         w_scale (Tensor): [n, k/2] input INT4 scale.
     """
     return Int4Weights(
-        weight=w.to(torch.int8).to(device=output_device),
+        weight=w.view(torch.int8).to(device=output_device),
         scale=scale.to(device=output_device),
         shape=w.shape,
     )


### PR DESCRIPTION
**Generate INT4 MP8 checkpoint:**
```
torchrun --nproc-per-node=8 -m models.llama4.scripts.quantize --ckpt_dir ../checkpoints/Llama-4-Scout-17B-16E-Instruct --output_dir ../checkpoints/Llama-4-Scout-17B-16E-Instruct-INT4 --quantization_mode int4_mixed --world_size 8
```
**Verify generated INT4 MP8 checkpoint with int4_mixed on single GPU ([output](https://gist.github.com/jiawenliu64/b95bf98944da04c27da1ea3625c5afd5)):**
```
PYTHONPATH=$(git rev-parse --show-toplevel) torchrun --nproc_per_node=1 -m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct-INT4 --world_size 1 --quantization-mode int4_mixed
```

**Generate FP8 MP8 checkpoint:**
```
torchrun --nproc-per-node=8 -m models.llama4.scripts.quantize --ckpt_dir ../checkpoints/Llama-4-Scout-17B-16E-Instruct --output_dir ../checkpoints/Llama-4-Scout-17B-16E-Instruct-FP8 --quantization_mode fp8_mixed --world_size 8
```
**Verify generated FP8 MP8 checkpoint with fp8_mixed ([output](https://gist.github.com/jiawenliu64/1512caf9fdfc3ddc38ecc09608796b8d)):**
```
PYTHONPATH=$(git rev-parse --show-toplevel) torchrun --nproc_per_node=8 -m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct-FP8 --world_size 8 --quantization-mode fp8_mixed
```

**Verify BF16 MP8 checkpoint ([output](https://gist.github.com/jiawenliu64/4968a4c61121f9a4cb4eb46995aadb33)):**
```
PYTHONPATH=$(git rev-parse --show-toplevel) torchrun --nproc_per_node=8 -m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct --world_size 8
```
**Verify BF16 MP8 checkpoint with fp8_mixed ([output](https://gist.github.com/jiawenliu64/55759166c92cb896fefad4f301ade9ca)):**
```
PYTHONPATH=$(git rev-parse --show-toplevel) torchrun --nproc_per_node=8 -m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct --world_size 8 --quantization-mode fp8_mixed
```
**Verify BF16 MP8 checkpoint with int4_mixed on single GPU ([output](https://gist.github.com/jiawenliu64/9bb85fd251a400a10ee6c824fb958f15)):**
```
PYTHONPATH=$(git rev-parse --show-toplevel) torchrun --nproc_per_node=1 -m models.llama4.scripts.chat_completion ../checkpoints/Llama-4-Scout-17B-16E-Instruct --world_size 1 --quantization-mode int4_mixed
```