### PR TITLE
fix(prompt-adapter): resolve Llama4 tool calling 500 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.egg-info
 build
 .DS_Store
+.vscode/

--- a/models/llama4/chat_format.py
+++ b/models/llama4/chat_format.py
@@ -6,6 +6,7 @@
 # the top-level of this source tree.
 
 import io
+import json
 import uuid
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
@@ -298,6 +299,7 @@ class ChatFormat:
                     call_id=call_id,
                     tool_name=tool_name,
                     arguments=tool_arguments,
+                    arguments_json=json.dumps(tool_arguments),
                 )
             )
             content = ""

--- a/models/llama4/tests/__init__.py
+++ b/models/llama4/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.

--- a/models/llama4/tests/api/__init__.py
+++ b/models/llama4/tests/api/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.

--- a/models/llama4/tests/api/test_chat_format.py
+++ b/models/llama4/tests/api/test_chat_format.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+import json
+import unittest
+from unittest.mock import Mock
+
+from llama_models.datatypes import BuiltinTool, StopReason
+from llama_models.llama4.chat_format import ChatFormat
+from llama_models.llama4.tokenizer import Tokenizer
+
+
+class TestChatFormatArgumentsJson(unittest.TestCase):
+    """Test that ToolCall objects include the arguments_json parameter."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Mock the tokenizer to avoid dependency issues in tests
+        self.mock_tokenizer = Mock(spec=Tokenizer)
+        self.chat_format = ChatFormat(self.mock_tokenizer)
+
+    def test_arguments_json_included_in_custom_tool_call(self):
+        """Test that arguments_json is included for custom tool calls."""
+        # Mock content that represents a custom tool call in python_list format
+        content = '[get_weather(location="San Francisco", units="metric")]'
+
+        # Mock the ToolUtils.maybe_extract_custom_tool_call to return our test data
+        with unittest.mock.patch(
+            "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_custom_tool_call"
+        ) as mock_extract:
+            mock_extract.return_value = ("get_weather", {"location": "San Francisco", "units": "metric"})
+
+            # Call the method under test
+            result = self.chat_format.decode_assistant_message_from_content(content, StopReason.end_of_turn)
+
+            # Verify the result
+            self.assertEqual(len(result.tool_calls), 1)
+            tool_call = result.tool_calls[0]
+
+            # Verify all expected fields are present
+            self.assertIsNotNone(tool_call.call_id)
+            self.assertEqual(tool_call.tool_name, "get_weather")
+            self.assertEqual(tool_call.arguments, {"location": "San Francisco", "units": "metric"})
+
+            # This is the critical test - verify arguments_json is included
+            self.assertIsNotNone(tool_call.arguments_json)
+            self.assertEqual(tool_call.arguments_json, '{"location": "San Francisco", "units": "metric"}')
+
+            # Verify arguments_json is valid JSON that matches arguments
+            parsed_args = json.loads(tool_call.arguments_json)
+            self.assertEqual(parsed_args, tool_call.arguments)
+
+    def test_arguments_json_included_in_builtin_tool_call(self):
+        """Test that arguments_json is included for builtin tool calls."""
+        # Mock content that represents a builtin tool call
+        content = "search for weather in San Francisco"
+
+        # Mock the ToolUtils methods to simulate builtin tool extraction
+        with (
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_custom_tool_call"
+            ) as mock_custom,
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_builtin_tool_call"
+            ) as mock_builtin,
+        ):
+            mock_custom.return_value = None  # No custom tool
+            mock_builtin.return_value = ("brave_search", "weather in San Francisco")
+
+            # Call the method under test
+            result = self.chat_format.decode_assistant_message_from_content(content, StopReason.end_of_turn)
+
+            # Verify the result
+            self.assertEqual(len(result.tool_calls), 1)
+            tool_call = result.tool_calls[0]
+
+            # Verify all expected fields are present
+            self.assertIsNotNone(tool_call.call_id)
+            self.assertEqual(tool_call.tool_name, BuiltinTool.brave_search)
+            self.assertEqual(tool_call.arguments, {"query": "weather in San Francisco"})
+
+            # This is the critical test - verify arguments_json is included
+            self.assertIsNotNone(tool_call.arguments_json)
+            self.assertEqual(tool_call.arguments_json, '{"query": "weather in San Francisco"}')
+
+            # Verify arguments_json is valid JSON that matches arguments
+            parsed_args = json.loads(tool_call.arguments_json)
+            self.assertEqual(parsed_args, tool_call.arguments)
+
+    def test_arguments_json_included_in_code_interpreter_call(self):
+        """Test that arguments_json is included for code interpreter tool calls."""
+        # Mock content that represents a code interpreter tool call
+        content = "run some python code"
+
+        # Mock the ToolUtils methods to simulate code interpreter tool extraction
+        with (
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_custom_tool_call"
+            ) as mock_custom,
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_builtin_tool_call"
+            ) as mock_builtin,
+        ):
+            mock_custom.return_value = None  # No custom tool
+            mock_builtin.return_value = ("code_interpreter", "print('Hello, World!')")
+
+            # Call the method under test
+            result = self.chat_format.decode_assistant_message_from_content(content, StopReason.end_of_turn)
+
+            # Verify the result
+            self.assertEqual(len(result.tool_calls), 1)
+            tool_call = result.tool_calls[0]
+
+            # Verify all expected fields are present
+            self.assertIsNotNone(tool_call.call_id)
+            self.assertEqual(tool_call.tool_name, BuiltinTool.code_interpreter)
+            self.assertEqual(tool_call.arguments, {"query": "print('Hello, World!')"})
+
+            # This is the critical test - verify arguments_json is included
+            self.assertIsNotNone(tool_call.arguments_json)
+            self.assertEqual(tool_call.arguments_json, '{"query": "print(\'Hello, World!\')"}')
+
+            # Verify arguments_json is valid JSON that matches arguments
+            parsed_args = json.loads(tool_call.arguments_json)
+            self.assertEqual(parsed_args, tool_call.arguments)
+
+    def test_arguments_json_with_complex_arguments(self):
+        """Test that arguments_json handles complex arguments correctly."""
+        # Mock content that represents a custom tool call with complex but supported arguments
+        content = '[complex_function(title="My Title", numbers=[1, 2, 3], enabled=true, score=3.14)]'
+
+        # Mock the ToolUtils.maybe_extract_custom_tool_call to return our test data
+        with unittest.mock.patch(
+            "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_custom_tool_call"
+        ) as mock_extract:
+            complex_args = {"title": "My Title", "numbers": [1, 2, 3], "enabled": True, "score": 3.14}
+            mock_extract.return_value = ("complex_function", complex_args)
+
+            # Call the method under test
+            result = self.chat_format.decode_assistant_message_from_content(content, StopReason.end_of_turn)
+
+            # Verify the result
+            self.assertEqual(len(result.tool_calls), 1)
+            tool_call = result.tool_calls[0]
+
+            # Verify all expected fields are present
+            self.assertIsNotNone(tool_call.call_id)
+            self.assertEqual(tool_call.tool_name, "complex_function")
+            self.assertEqual(tool_call.arguments, complex_args)
+
+            # This is the critical test - verify arguments_json is included
+            self.assertIsNotNone(tool_call.arguments_json)
+
+            # Verify arguments_json is valid JSON that matches arguments
+            parsed_args = json.loads(tool_call.arguments_json)
+            self.assertEqual(parsed_args, tool_call.arguments)
+
+            # Verify the JSON string contains the expected structure
+            expected_json = '{"title": "My Title", "numbers": [1, 2, 3], "enabled": true, "score": 3.14}'
+            self.assertEqual(tool_call.arguments_json, expected_json)
+
+    def test_no_tool_calls_when_no_tools_detected(self):
+        """Test that no tool calls are created when no tools are detected."""
+        content = "Just a regular response with no tool calls."
+
+        # Mock the ToolUtils methods to return None (no tools detected)
+        with (
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_custom_tool_call"
+            ) as mock_custom,
+            unittest.mock.patch(
+                "llama_models.llama3.tool_utils.ToolUtils.maybe_extract_builtin_tool_call"
+            ) as mock_builtin,
+        ):
+            mock_custom.return_value = None
+            mock_builtin.return_value = None
+
+            # Call the method under test
+            result = self.chat_format.decode_assistant_message_from_content(content, StopReason.end_of_turn)
+
+            # Verify no tool calls are created
+            self.assertEqual(len(result.tool_calls), 0)
+            self.assertEqual(result.content, content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Llama4 tool calling was causing 500 errors due to missing `arguments_json` parameter in ToolCall objects. Systems downstream expect this field to be present for proper tool execution.

## Solution

- **Fixed missing `arguments_json` parameter** in `decode_assistant_message_from_content` method
- **Added comprehensive test suite** with 5 pytest-compatible tests covering:
  - Custom tool calls  
  - Builtin tool calls (brave_search, code_interpreter, etc.)
  - Complex argument structures
  - Edge cases and validation

## Testing

```bash
pytest models/llama4/tests/api/test_chat_format.py -v
======= 5 passed in 1.46s =======
```

## Related

- Addresses Issue #2584 (PR #2663 reviewer feedback)
- Fixes compatibility with systems expecting `arguments_json` field
- Maintains backward compatibility with existing `arguments` field

## Validation

All tool call types now properly include `arguments_json` field with valid JSON serialization that matches the `arguments` dict.