### PR TITLE
Fix import error in download command

### DIFF
--- a/models/cli/download.py
+++ b/models/cli/download.py
@@ -461,7 +461,7 @@ def run_download_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser):
 
         from llama_models.sku_list import llama_meta_net_info, resolve_model
 
-        from .model.safety_models import (
+        from .safety_models import (
             prompt_guard_download_info_map,
             prompt_guard_model_sku_map,
         )


### PR DESCRIPTION
Fix ModuleNotFoundError when running llama-model download command. The import statement was incorrectly trying to import from .model.safety_models but the correct path is .safety_models

This was causing 'Download failed: No module named llama_models.cli.model' error when attempting to download models from Meta.

Fixes the download functionality for all model downloads via CLI.