### PR TITLE
test: add unit tests for CLI commands

### DIFF
--- a/models/cli/tests/__init__.py
+++ b/models/cli/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.

--- a/models/cli/tests/test_describe.py
+++ b/models/cli/tests/test_describe.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+import argparse
+import unittest
+from unittest.mock import MagicMock, patch
+
+from llama_models.cli.describe import Describe
+
+
+class TestDescribeCommand(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+        self.describe_cmd = Describe(self.subparsers)
+
+    def test_describe_command_parser_created(self):
+        assert self.describe_cmd.parser is not None
+
+    def test_describe_command_requires_model_id(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["describe"])
+
+    def test_describe_command_accepts_model_id(self):
+        args = self.parser.parse_args(["describe", "--model-id", "Llama-3.1:8B"])
+        assert args.model_id == "Llama-3.1:8B"
+
+    def test_describe_command_short_model_id_argument(self):
+        args = self.parser.parse_args(["describe", "-m", "Llama-4-Scout:17B"])
+        assert args.model_id == "Llama-4-Scout:17B"
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.describe.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_run_describe_cmd_success(self, mock_safety_map, mock_print, mock_resolve):
+        mock_safety_map.return_value = {}
+
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Llama-3.1:8B"
+        mock_model.huggingface_repo = "meta-llama/Llama-3.1-8B"
+        mock_model.description = "A powerful language model"
+        mock_model.max_seq_length = 131072
+        mock_model.quantization_format.value = "bf16"
+        mock_model.arch_args = {"dim": 4096, "n_layers": 32}
+
+        mock_resolve.return_value = mock_model
+
+        args = self.parser.parse_args(["describe", "-m", "Llama-3.1:8B"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args[0][0]
+        headers = mock_print.call_args[0][1]
+
+        assert headers[0] == "Model"
+        assert headers[1] == "Llama-3.1:8B"
+
+        row_dict = {row[0]: row[1] for row in rows}
+        assert row_dict["Hugging Face ID"] == "meta-llama/Llama-3.1-8B"
+        assert row_dict["Description"] == "A powerful language model"
+        assert row_dict["Context Length"] == "128K tokens"
+        assert row_dict["Weights format"] == "bf16"
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_run_describe_cmd_model_not_found(self, mock_safety_map, mock_resolve):
+        mock_safety_map.return_value = {}
+        mock_resolve.return_value = None
+
+        args = self.parser.parse_args(["describe", "-m", "NonExistent:Model"])
+
+        with self.assertRaises(SystemExit):
+            args.func(args)
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.describe.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_run_describe_cmd_no_huggingface_repo(self, mock_safety_map, mock_print, mock_resolve):
+        mock_safety_map.return_value = {}
+
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Custom:Model"
+        mock_model.huggingface_repo = None
+        mock_model.description = "Custom model"
+        mock_model.max_seq_length = 4096
+        mock_model.quantization_format.value = "fp16"
+        mock_model.arch_args = {}
+
+        mock_resolve.return_value = mock_model
+
+        args = self.parser.parse_args(["describe", "-m", "Custom:Model"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args[0][0]
+        row_dict = {row[0]: row[1] for row in rows}
+        assert row_dict["Hugging Face ID"] == "<Not Available>"
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.describe.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_run_describe_cmd_prompt_guard_model(self, mock_safety_map, mock_print, mock_resolve):
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Prompt-Guard:86M"
+        mock_model.huggingface_repo = "meta-llama/Prompt-Guard-86M"
+        mock_model.description = "Safety model"
+        mock_model.max_seq_length = 512
+        mock_model.quantization_format.value = "bf16"
+        mock_model.arch_args = {}
+
+        mock_safety_map.return_value = {"Prompt-Guard:86M": mock_model}
+        mock_resolve.return_value = None
+
+        args = self.parser.parse_args(["describe", "-m", "Prompt-Guard:86M"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        mock_resolve.assert_not_called()
+
+
+class TestDescribeCommandContextLengthFormatting(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+        self.describe_cmd = Describe(self.subparsers)
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.describe.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_context_length_formatting_128k(self, mock_safety_map, mock_print, mock_resolve):
+        mock_safety_map.return_value = {}
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Test:Model"
+        mock_model.huggingface_repo = "test/model"
+        mock_model.description = "Test"
+        mock_model.max_seq_length = 131072
+        mock_model.quantization_format.value = "bf16"
+        mock_model.arch_args = {}
+        mock_resolve.return_value = mock_model
+
+        args = self.parser.parse_args(["describe", "-m", "Test:Model"])
+        args.func(args)
+
+        rows = mock_print.call_args[0][0]
+        row_dict = {row[0]: row[1] for row in rows}
+        assert row_dict["Context Length"] == "128K tokens"
+
+    @patch("llama_models.cli.describe.resolve_model")
+    @patch("llama_models.cli.describe.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_sku_map")
+    def test_context_length_formatting_10m(self, mock_safety_map, mock_print, mock_resolve):
+        mock_safety_map.return_value = {}
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Llama-4-Scout:17B"
+        mock_model.huggingface_repo = "meta-llama/Llama-4-Scout"
+        mock_model.description = "Llama 4 Scout MoE"
+        mock_model.max_seq_length = 10485760
+        mock_model.quantization_format.value = "bf16"
+        mock_model.arch_args = {}
+        mock_resolve.return_value = mock_model
+
+        args = self.parser.parse_args(["describe", "-m", "Llama-4-Scout:17B"])
+        args.func(args)
+
+        rows = mock_print.call_args[0][0]
+        row_dict = {row[0]: row[1] for row in rows}
+        assert row_dict["Context Length"] == "10240K tokens"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/models/cli/tests/test_download.py
+++ b/models/cli/tests/test_download.py
@@ -1,0 +1,227 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+import argparse
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from llama_models.cli.download import (
+    CustomTransferSpeedColumn,
+    Download,
+    DownloadError,
+    DownloadTask,
+    ModelEntry,
+    ParallelDownloader,
+    setup_download_parser,
+)
+
+
+class TestDownloadTask(unittest.TestCase):
+    def test_download_task_creation(self):
+        task = DownloadTask(url="https://example.com/model.bin", output_file="/tmp/model.bin")
+        assert task.url == "https://example.com/model.bin"
+        assert task.output_file == "/tmp/model.bin"
+        assert task.total_size == 0
+        assert task.downloaded_size == 0
+        assert task.task_id is None
+        assert task.retries == 0
+        assert task.max_retries == 3
+
+    def test_download_task_with_all_fields(self):
+        task = DownloadTask(
+            url="https://example.com/model.bin",
+            output_file="/tmp/model.bin",
+            total_size=1000000,
+            downloaded_size=500000,
+            task_id=1,
+            retries=2,
+            max_retries=5,
+        )
+        assert task.total_size == 1000000
+        assert task.downloaded_size == 500000
+        assert task.task_id == 1
+        assert task.retries == 2
+        assert task.max_retries == 5
+
+
+class TestDownloadError(unittest.TestCase):
+    def test_download_error_is_exception(self):
+        assert issubclass(DownloadError, Exception)
+
+    def test_download_error_can_be_raised(self):
+        with self.assertRaises(DownloadError):
+            raise DownloadError("Test error")
+
+
+class TestModelEntry(unittest.TestCase):
+    def test_model_entry_creation(self):
+        entry = ModelEntry(model_id="Llama-3.1:8B", files={"model.bin": "https://example.com/model.bin"})
+        assert entry.model_id == "Llama-3.1:8B"
+        assert entry.files == {"model.bin": "https://example.com/model.bin"}
+
+
+class TestCustomTransferSpeedColumn(unittest.TestCase):
+    def test_render_with_speed(self):
+        column = CustomTransferSpeedColumn()
+        mock_task = MagicMock()
+        mock_task.finished = False
+        mock_task.speed = 1024 * 1024
+
+        result = column.render(mock_task)
+        assert result is not None
+
+    def test_render_finished_task(self):
+        column = CustomTransferSpeedColumn()
+        mock_task = MagicMock()
+        mock_task.finished = True
+
+        result = column.render(mock_task)
+        assert result is not None
+
+
+class TestDownloadCommand(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+        self.download_cmd = Download(self.subparsers)
+
+    def test_download_command_parser_created(self):
+        assert self.download_cmd.parser is not None
+
+
+class TestSetupDownloadParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        setup_download_parser(self.parser)
+
+    def test_parser_has_model_id_argument(self):
+        args = self.parser.parse_args(["--model-id", "Llama-3.1:8B"])
+        assert args.model_id == "Llama-3.1:8B"
+
+    def test_parser_has_source_argument(self):
+        args = self.parser.parse_args(["--source", "meta"])
+        assert args.source == "meta"
+
+    def test_parser_source_choices(self):
+        args = self.parser.parse_args(["--source", "huggingface"])
+        assert args.source == "huggingface"
+
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--source", "invalid"])
+
+    def test_parser_has_hf_token_argument(self):
+        args = self.parser.parse_args(["--hf-token", "hf_xxx"])
+        assert args.hf_token == "hf_xxx"
+
+    def test_parser_has_ignore_patterns_argument(self):
+        args = self.parser.parse_args(["--ignore-patterns", "*.md"])
+        assert args.ignore_patterns == "*.md"
+
+    def test_parser_has_max_parallel_argument(self):
+        args = self.parser.parse_args(["--max-parallel", "5"])
+        assert args.max_parallel == 5
+
+    def test_parser_has_meta_url_argument(self):
+        args = self.parser.parse_args(["--meta-url", "https://example.com"])
+        assert args.meta_url == "https://example.com"
+
+    def test_parser_has_manifest_file_argument(self):
+        args = self.parser.parse_args(["--manifest-file", "/path/to/manifest.json"])
+        assert args.manifest_file == "/path/to/manifest.json"
+
+
+class TestParallelDownloader(unittest.TestCase):
+    def test_parallel_downloader_initialization(self):
+        downloader = ParallelDownloader()
+        assert downloader.max_concurrent_downloads == 3
+        assert downloader.buffer_size == 1024 * 1024
+        assert downloader.timeout == 30
+
+    def test_parallel_downloader_custom_params(self):
+        downloader = ParallelDownloader(max_concurrent_downloads=5, buffer_size=2048, timeout=60)
+        assert downloader.max_concurrent_downloads == 5
+        assert downloader.buffer_size == 2048
+        assert downloader.timeout == 60
+
+    def test_verify_file_integrity_with_matching_size(self):
+        downloader = ParallelDownloader()
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"test content")
+            f.flush()
+            temp_path = f.name
+
+        try:
+            file_size = Path(temp_path).stat().st_size
+            task = DownloadTask(url="https://example.com/test.bin", output_file=temp_path, total_size=file_size)
+            result = downloader.verify_file_integrity(task)
+            assert result is True
+        finally:
+            Path(temp_path).unlink()
+
+    def test_verify_file_integrity_file_not_found(self):
+        downloader = ParallelDownloader()
+        task = DownloadTask(url="https://example.com/test.bin", output_file="/nonexistent/path", total_size=100)
+        result = downloader.verify_file_integrity(task)
+        assert result is False
+
+    def test_has_disk_space_sufficient(self):
+        downloader = ParallelDownloader()
+
+        task = DownloadTask(
+            url="https://example.com/small.bin",
+            output_file="/tmp/small.bin",
+            total_size=1024,
+        )
+
+        result = downloader.has_disk_space([task])
+        assert result is True
+
+    def test_prepare_download_creates_directory(self):
+        downloader = ParallelDownloader()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "subdir" / "model.bin"
+            task = DownloadTask(url="https://example.com/model.bin", output_file=str(output_path))
+
+            asyncio.run(downloader.prepare_download(task))
+            assert output_path.parent.exists()
+
+
+class TestRetryWithExponentialBackoff(unittest.TestCase):
+    def test_retry_success_on_first_attempt(self):
+        downloader = ParallelDownloader()
+        task = DownloadTask(url="https://example.com", output_file="/tmp/test.bin")
+
+        async def mock_func():
+            return "success"
+
+        result = asyncio.run(downloader.retry_with_exponential_backoff(task, mock_func))
+        assert result == "success"
+
+    def test_retry_fails_eventually(self):
+        downloader = ParallelDownloader()
+        task = DownloadTask(url="https://example.com", output_file="/tmp/test.bin", max_retries=2)
+
+        call_count = 0
+
+        async def failing_func():
+            nonlocal call_count
+            call_count += 1
+            raise DownloadError("Network error")
+
+        with self.assertRaises(DownloadError):
+            asyncio.run(downloader.retry_with_exponential_backoff(task, failing_func))
+
+        assert call_count == task.max_retries
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/models/cli/tests/test_list.py
+++ b/models/cli/tests/test_list.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+import argparse
+import unittest
+from unittest.mock import MagicMock, patch
+
+from llama_models.cli.list import List, _convert_to_model_descriptor, _get_model_size
+
+
+class TestListHelperFunctions(unittest.TestCase):
+    def test_get_model_size_empty_dir(self):
+        with patch("pathlib.Path.rglob") as mock_rglob:
+            mock_rglob.return_value = []
+            size = _get_model_size("/fake/path")
+            assert size == 0
+
+    def test_get_model_size_with_files(self):
+        mock_file1 = MagicMock()
+        mock_file1.is_file.return_value = True
+        mock_file1.stat.return_value.st_size = 1000
+
+        mock_file2 = MagicMock()
+        mock_file2.is_file.return_value = True
+        mock_file2.stat.return_value.st_size = 2000
+
+        mock_dir = MagicMock()
+        mock_dir.is_file.return_value = False
+
+        with patch("pathlib.Path.rglob") as mock_rglob:
+            mock_rglob.return_value = [mock_file1, mock_file2, mock_dir]
+            size = _get_model_size("/fake/path")
+            assert size == 3000
+
+    @patch("llama_models.cli.list.all_registered_models")
+    def test_convert_to_model_descriptor_found(self, mock_models):
+        mock_model = MagicMock()
+        mock_model.descriptor.return_value = "Llama-3.1:8B"
+        mock_models.return_value = [mock_model]
+
+        result = _convert_to_model_descriptor("Llama-3.1-8B")
+        assert result == "Llama-3.1:8B"
+
+    @patch("llama_models.cli.list.all_registered_models")
+    def test_convert_to_model_descriptor_not_found(self, mock_models):
+        mock_models.return_value = []
+        result = _convert_to_model_descriptor("unknown-model")
+        assert result == "unknown-model"
+
+
+class TestListCommand(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+        self.list_cmd = List(self.subparsers)
+
+    def test_list_command_parser_created(self):
+        assert self.list_cmd.parser is not None
+
+    def test_list_command_has_show_all_argument(self):
+        args = self.parser.parse_args(["list", "--show-all"])
+        assert args.show_all is True
+
+    def test_list_command_has_downloaded_argument(self):
+        args = self.parser.parse_args(["list", "--downloaded"])
+        assert args.downloaded is True
+
+    def test_list_command_has_search_argument(self):
+        args = self.parser.parse_args(["list", "--search", "llama3"])
+        assert args.search == "llama3"
+
+    def test_list_command_short_search_argument(self):
+        args = self.parser.parse_args(["list", "-s", "llama4"])
+        assert args.search == "llama4"
+
+    @patch("llama_models.cli.list.all_registered_models")
+    @patch("llama_models.cli.list.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_skus")
+    def test_run_model_list_cmd_filters_featured(self, mock_safety, mock_print, mock_models):
+        featured_model = MagicMock()
+        featured_model.is_featured = True
+        featured_model.descriptor.return_value = "Llama-3.1:8B"
+        featured_model.huggingface_repo = "meta-llama/Llama-3.1-8B"
+        featured_model.max_seq_length = 131072
+
+        non_featured_model = MagicMock()
+        non_featured_model.is_featured = False
+        non_featured_model.descriptor.return_value = "Llama-2:7B"
+
+        mock_models.return_value = [featured_model, non_featured_model]
+        mock_safety.return_value = []
+
+        args = self.parser.parse_args(["list"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args[0][0]
+        assert len(rows) == 1
+        assert rows[0][0] == "Llama-3.1:8B"
+
+    @patch("llama_models.cli.list.all_registered_models")
+    @patch("llama_models.cli.list.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_skus")
+    def test_run_model_list_cmd_show_all(self, mock_safety, mock_print, mock_models):
+        featured_model = MagicMock()
+        featured_model.is_featured = True
+        featured_model.descriptor.return_value = "Llama-3.1:8B"
+        featured_model.huggingface_repo = "meta-llama/Llama-3.1-8B"
+        featured_model.max_seq_length = 131072
+
+        non_featured_model = MagicMock()
+        non_featured_model.is_featured = False
+        non_featured_model.descriptor.return_value = "Llama-2:7B"
+        non_featured_model.huggingface_repo = "meta-llama/Llama-2-7b"
+        non_featured_model.max_seq_length = 4096
+
+        mock_models.return_value = [featured_model, non_featured_model]
+        mock_safety.return_value = []
+
+        args = self.parser.parse_args(["list", "--show-all"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args[0][0]
+        assert len(rows) == 2
+
+    @patch("llama_models.cli.list.all_registered_models")
+    @patch("llama_models.cli.list.print_table")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_skus")
+    def test_run_model_list_cmd_search_filter(self, mock_safety, mock_print, mock_models):
+        model1 = MagicMock()
+        model1.is_featured = True
+        model1.descriptor.return_value = "Llama-3.1:8B"
+        model1.huggingface_repo = "meta-llama/Llama-3.1-8B"
+        model1.max_seq_length = 131072
+
+        model2 = MagicMock()
+        model2.is_featured = True
+        model2.descriptor.return_value = "Llama-4-Scout:17B"
+        model2.huggingface_repo = "meta-llama/Llama-4-Scout"
+        model2.max_seq_length = 10485760
+
+        mock_models.return_value = [model1, model2]
+        mock_safety.return_value = []
+
+        args = self.parser.parse_args(["list", "--search", "llama-4"])
+        args.func(args)
+
+        mock_print.assert_called_once()
+        rows = mock_print.call_args[0][0]
+        assert len(rows) == 1
+        assert rows[0][0] == "Llama-4-Scout:17B"
+
+    @patch("llama_models.cli.list.all_registered_models")
+    @patch("builtins.print")
+    @patch("llama_models.cli.safety_models.prompt_guard_model_skus")
+    def test_run_model_list_cmd_search_no_results(self, mock_safety, mock_print, mock_models):
+        mock_models.return_value = []
+        mock_safety.return_value = []
+
+        args = self.parser.parse_args(["list", "--search", "nonexistent"])
+        args.func(args)
+
+        mock_print.assert_called_with("Did not find any model matching `nonexistent`.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/models/cli/tests/test_verify_download.py
+++ b/models/cli/tests/test_verify_download.py
@@ -1,0 +1,256 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# top-level folder for each specific model found within the models/ directory at
+# the top-level of this source tree.
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from llama_models.cli.verify_download import (
+    VerificationResult,
+    VerifyDownload,
+    calculate_sha256,
+    load_checksums,
+    setup_verify_download_parser,
+    verify_files,
+)
+
+
+class TestVerificationResult(unittest.TestCase):
+    def test_verification_result_creation(self):
+        result = VerificationResult(
+            filename="model.safetensors",
+            expected_hash="abc123",
+            actual_hash="abc123",
+            exists=True,
+            matches=True,
+        )
+        assert result.filename == "model.safetensors"
+        assert result.expected_hash == "abc123"
+        assert result.actual_hash == "abc123"
+        assert result.exists is True
+        assert result.matches is True
+
+    def test_verification_result_mismatch(self):
+        result = VerificationResult(
+            filename="model.safetensors",
+            expected_hash="abc123",
+            actual_hash="def456",
+            exists=True,
+            matches=False,
+        )
+        assert result.matches is False
+
+    def test_verification_result_missing_file(self):
+        result = VerificationResult(
+            filename="missing.bin",
+            expected_hash="abc123",
+            actual_hash=None,
+            exists=False,
+            matches=False,
+        )
+        assert result.exists is False
+        assert result.actual_hash is None
+
+
+class TestCalculateSha256(unittest.TestCase):
+    def test_calculate_sha256_small_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"Hello, World!")
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            expected_hash = "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+            actual_hash = calculate_sha256(temp_path)
+            assert actual_hash == expected_hash
+        finally:
+            temp_path.unlink()
+
+    def test_calculate_sha256_empty_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            expected_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            actual_hash = calculate_sha256(temp_path)
+            assert actual_hash == expected_hash
+        finally:
+            temp_path.unlink()
+
+
+class TestLoadChecksums(unittest.TestCase):
+    def test_load_checksums_standard_format(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".chk", delete=False) as f:
+            f.write("abc123def456  model.safetensors\n")
+            f.write("789xyz000111  tokenizer.model\n")
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            checksums = load_checksums(temp_path)
+            assert len(checksums) == 2
+            assert checksums["model.safetensors"] == "abc123def456"
+            assert checksums["tokenizer.model"] == "789xyz000111"
+        finally:
+            temp_path.unlink()
+
+    def test_load_checksums_with_leading_dotslash(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".chk", delete=False) as f:
+            f.write("abc123  ./model.safetensors\n")
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            checksums = load_checksums(temp_path)
+            assert checksums["model.safetensors"] == "abc123"
+        finally:
+            temp_path.unlink()
+
+    def test_load_checksums_with_subdirectory(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".chk", delete=False) as f:
+            f.write("abc123  subdir/model.safetensors\n")
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            checksums = load_checksums(temp_path)
+            assert checksums["subdir/model.safetensors"] == "abc123"
+        finally:
+            temp_path.unlink()
+
+    def test_load_checksums_empty_lines_ignored(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".chk", delete=False) as f:
+            f.write("abc123  model.safetensors\n")
+            f.write("\n")
+            f.write("def456  tokenizer.model\n")
+            f.flush()
+            temp_path = Path(f.name)
+
+        try:
+            checksums = load_checksums(temp_path)
+            assert len(checksums) == 2
+        finally:
+            temp_path.unlink()
+
+
+class TestVerifyDownloadCommand(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        self.subparsers = self.parser.add_subparsers()
+        self.verify_cmd = VerifyDownload(self.subparsers)
+
+    def test_verify_download_command_parser_created(self):
+        assert self.verify_cmd.parser is not None
+
+    def test_verify_download_command_requires_model_id(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["verify-download"])
+
+    def test_verify_download_command_accepts_model_id(self):
+        args = self.parser.parse_args(["verify-download", "--model-id", "Llama-3.1:8B"])
+        assert args.model_id == "Llama-3.1:8B"
+
+
+class TestSetupVerifyDownloadParser(unittest.TestCase):
+    def test_setup_adds_model_id_argument(self):
+        parser = argparse.ArgumentParser()
+        setup_verify_download_parser(parser)
+
+        args = parser.parse_args(["--model-id", "test-model"])
+        assert args.model_id == "test-model"
+
+    def test_setup_sets_func_default(self):
+        parser = argparse.ArgumentParser()
+        setup_verify_download_parser(parser)
+
+        args = parser.parse_args(["--model-id", "test"])
+        assert hasattr(args, "func")
+        assert callable(args.func)
+
+
+class TestVerifyFilesFunction(unittest.TestCase):
+    def test_verify_files_all_pass(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+
+            file1 = model_dir / "model.bin"
+            file1.write_bytes(b"test content 1")
+            file1_hash = calculate_sha256(file1)
+
+            file2 = model_dir / "tokenizer.model"
+            file2.write_bytes(b"test content 2")
+            file2_hash = calculate_sha256(file2)
+
+            checksums = {"model.bin": file1_hash, "tokenizer.model": file2_hash}
+
+            mock_console = MagicMock()
+            results = verify_files(model_dir, checksums, mock_console)
+
+            assert len(results) == 2
+            for result in results:
+                assert result.exists is True
+                assert result.matches is True
+
+    def test_verify_files_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+            checksums = {"nonexistent.bin": "abc123"}
+
+            mock_console = MagicMock()
+            results = verify_files(model_dir, checksums, mock_console)
+
+            assert len(results) == 1
+            assert results[0].exists is False
+            assert results[0].matches is False
+
+    def test_verify_files_hash_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+
+            file1 = model_dir / "model.bin"
+            file1.write_bytes(b"actual content")
+
+            checksums = {"model.bin": "wrong_hash_value"}
+
+            mock_console = MagicMock()
+            results = verify_files(model_dir, checksums, mock_console)
+
+            assert len(results) == 1
+            assert results[0].exists is True
+            assert results[0].matches is False
+            assert results[0].actual_hash != "wrong_hash_value"
+
+
+class TestRunVerifyCommand(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+        setup_verify_download_parser(self.parser)
+
+    @patch("llama_models.utils.model_utils.model_local_dir")
+    def test_run_verify_cmd_model_dir_not_found(self, mock_local_dir):
+        mock_local_dir.return_value = "/nonexistent/path"
+
+        args = self.parser.parse_args(["--model-id", "test-model"])
+
+        with self.assertRaises(SystemExit):
+            args.func(args)
+
+    @patch("llama_models.utils.model_utils.model_local_dir")
+    def test_run_verify_cmd_checklist_not_found(self, mock_local_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_local_dir.return_value = tmpdir
+
+            args = self.parser.parse_args(["--model-id", "test-model"])
+
+            with self.assertRaises(SystemExit):
+                args.func(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add comprehensive unit test suite for CLI module covering:
- list.py: model listing with search and filter options
- describe.py: model description and metadata display
- verify_download.py: checksum verification for downloaded models
- download.py: parallel download functionality

Tests use mocks to avoid network and GPU dependencies.

Total: 66 tests across 4 files.