### PR TITLE
Reduce peak vram in moe.py by avoiding cached router indices 

### DIFF
--- a/models/llama4/moe.py
+++ b/models/llama4/moe.py
@@ -200,10 +200,9 @@ class MoE(torch.nn.Module):
         out_aD = self.shared_expert(x_aD)
         routed_out_eg_D = self.experts(routed_in_EG_D.detach())
 
-        router_indices_EG_D = router_indices.reshape(-1, 1).expand(-1, D)
         out_aD.scatter_add_(
             dim=0,
-            index=router_indices_EG_D,
+            index=router_indices.reshape(-1, 1).expand(-1, D),
             src=routed_out_eg_D.view(-1, D),
         )
         out_aD = reduce_from_model_parallel_region(out_aD)


### PR DESCRIPTION
Currently, the expanded router indices in moe.py forward pass is computed on the fly in gather operation but it is recomputed and assigned to a variable just before the scatter_add_ operation. Holding them in memory while experts are executing increases peak memory pressure during the most memory-intensive part of the layer (expert mlps) 

This PR switches to calculating the indices on-the-fly for both the gather and scatter_add_ operations. This way, the index tensor can be garbage collected while the experts are running, which effectively reduces memory usage of the forward pass with negligible compute overhead. 