### PR TITLE
Fix incorrect import in download CLI causing ModuleNotFoundError

### DIFF
--- a/models/cli/download.py
+++ b/models/cli/download.py
@@ -461,7 +461,7 @@ def run_download_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser):
 
         from llama_models.sku_list import llama_meta_net_info, resolve_model
 
-        from .model.safety_models import (
+        from .safety_models import (
             prompt_guard_download_info_map,
             prompt_guard_model_sku_map,
         )


### PR DESCRIPTION
Fixes #475

## Issue
Running:
llama-model download ...

Results in:
ModuleNotFoundError: No module named 'llama_models.cli.model'

## Root Cause
The code imports from `.model.safety_models`, but the `model` submodule does not exist.

`safety_models.py` is located directly under `models/cli/`.

## Fix
Updated import from:
- .model.safety_models

to:
- .safety_models

## Verification
- Reproduced issue on clean setup
- After fix, CLI runs successfully and proceeds to download step

### Before
ModuleNotFoundError: No module named 'llama_models.cli.model'
<img width="1919" height="843" alt="image" src="https://github.com/user-attachments/assets/acf97cf1-e1ec-4e04-8117-5e2f581140f7" />



### After
CLI runs successfully and prompts for download URL

<img width="1919" height="906" alt="Screenshot 2026-04-15 163813" src="https://github.com/user-attachments/assets/c0fbc7bf-55fe-44e7-8cb9-fbc8f1ddfe65" />
